### PR TITLE
Fixing routing issue

### DIFF
--- a/src/app/shared/components/breadcrumbs/breadcrumbs.module.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
-import { RouterTestingModule } from '@angular/router/testing';
+import { AppRoutingModule } from 'src/app/app-routing.module';
 
 @NgModule({
   declarations: [BreadcrumbsComponent],
-  imports: [CommonModule, RouterTestingModule],
+  imports: [CommonModule, AppRoutingModule],
   exports: [BreadcrumbsComponent],
 })
 export class BreadcrumbsModule {}


### PR DESCRIPTION
### Description:
Don't accidentally use RouterTestingModule. By using RouterTestingModule, it allows for as expected routing except whenever you navigate, the url will not update. This, weirdly enough, blows up routing throughout the entire app. In the case of this project, RouterTestingModule was in the breadcrumbs module. 