### PR TITLE
NOBUG: changing placeholder text

### DIFF
--- a/src/app/forms/backcountry-camping/sections/backcountry-camping-section/backcountry-camping-section.component.html
+++ b/src/app/forms/backcountry-camping/sections/backcountry-camping-section/backcountry-camping-section.component.html
@@ -5,7 +5,6 @@
         <app-text-input
           [label]="'People'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="peopleField"
           [type]="'number'"
         ></app-text-input>

--- a/src/app/forms/day-use/sections/people-and-vehicles/people-and-vehicles.component.html
+++ b/src/app/forms/day-use/sections/people-and-vehicles/people-and-vehicles.component.html
@@ -5,7 +5,6 @@
         <app-text-input
           [label]="'Trail counter'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="peopleAndVehiclesTrailField"
           [type]="'number'"
         ></app-text-input>
@@ -25,14 +24,12 @@
           [label]="'Vehicle count'"
           [icon]="'bi-person-fill'"
           [control]="peopleAndVehiclesVehicleField"
-          [placeholder]="'0'"
           [type]="'number'"
         ></app-text-input>
         <app-text-input
           [label]="'Bus count'"
           [icon]="'bi-person-fill'"
           [control]="peopleAndVehiclesBusField"
-          [placeholder]="'0'"
           [type]="'number'"
         ></app-text-input>
       </div>

--- a/src/app/forms/day-use/sections/picnic-shelters/picnic-shelters.component.html
+++ b/src/app/forms/day-use/sections/picnic-shelters/picnic-shelters.component.html
@@ -4,7 +4,6 @@
       <app-text-input
         [label]="'Parties'"
         [icon]="'bi-person-fill'"
-        [placeholder]="'0'"
         [control]="picnicRevenueShelterControl"
         [type]="'number'"
       ></app-text-input>

--- a/src/app/forms/frontcountry-cabins/sections/frontcountry-cabins-section/frontcountry-cabins-section.component.html
+++ b/src/app/forms/frontcountry-cabins/sections/frontcountry-cabins-section/frontcountry-cabins-section.component.html
@@ -5,7 +5,6 @@
         <app-text-input
           [label]="'Parties'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="totalAttendancePartiesField"
           [type]="'number'"
         ></app-text-input>

--- a/src/app/forms/frontcountry-camping/sections/additional-vehicles/additional-vehicles.component.html
+++ b/src/app/forms/frontcountry-camping/sections/additional-vehicles/additional-vehicles.component.html
@@ -5,7 +5,6 @@
         <app-text-input
           [label]="'Standard'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="secondCarsAttendanceStandardField"
           [type]="'number'"
         ></app-text-input>
@@ -14,7 +13,6 @@
         <app-text-input
           [label]="'Senior'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="secondCarsAttendanceSeniorField"
           [type]="'number'"
         ></app-text-input>
@@ -23,7 +21,6 @@
         <app-text-input
           [label]="'Social services fee exemption'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="secondCarsAttendanceSocialField"
           [type]="'number'"
         ></app-text-input>

--- a/src/app/forms/frontcountry-camping/sections/camping-party-nights/camping-party-nights.component.html
+++ b/src/app/forms/frontcountry-camping/sections/camping-party-nights/camping-party-nights.component.html
@@ -5,7 +5,6 @@
         <app-text-input
           [label]="'Standard'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="campingPartyNightsAttendanceStandardField"
           [type]="'number'"
         ></app-text-input>
@@ -14,7 +13,6 @@
         <app-text-input
           [label]="'Senior'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="campingPartyNightsAttendanceSeniorField"
           [type]="'number'"
         ></app-text-input>
@@ -23,7 +21,6 @@
         <app-text-input
           [label]="'Social services fee exemption'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="campingPartyNightsAttendanceSocialField"
           [type]="'number'"
         ></app-text-input>
@@ -39,7 +36,6 @@
         <app-text-input
           [label]="'Long stay'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="campingPartyNightsAttendanceLongStayField"
           [type]="'number'"
         ></app-text-input>

--- a/src/app/forms/group-camping/sections/standard-rate-groups/standard-rate-groups.component.html
+++ b/src/app/forms/group-camping/sections/standard-rate-groups/standard-rate-groups.component.html
@@ -4,7 +4,6 @@
       <app-text-input
         [label]="'Standard night groups'"
         [icon]="'bi-person-fill'"
-        [placeholder]="'0'"
         [control]="standardRateGroupsTotalPeopleStandardField"
         [type]="'number'"
       ></app-text-input>
@@ -14,7 +13,6 @@
         <app-text-input
           [label]="'Adults (16+)'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="standardRateGroupsTotalPeopleAdultsField"
           [type]="'number'"
         ></app-text-input>
@@ -23,7 +21,6 @@
         <app-text-input
           [label]="'Youth (6-15)'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="standardRateGroupsTotalPeopleYouthField"
           [type]="'number'"
         ></app-text-input>
@@ -32,7 +29,6 @@
         <app-text-input
           [label]="'Kids (0-5)'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="standardRateGroupsTotalPeopleKidsField"
           [type]="'number'"
         ></app-text-input>

--- a/src/app/forms/group-camping/sections/youth-rate-groups/youth-rate-groups.component.html
+++ b/src/app/forms/group-camping/sections/youth-rate-groups/youth-rate-groups.component.html
@@ -4,7 +4,6 @@
       <app-text-input
         [label]="'Group nights'"
         [icon]="'bi-person-fill'"
-        [placeholder]="'0'"
         [control]="youthRateGroupsAttendanceGroupNightsField"
         [type]="'number'"
       ></app-text-input>
@@ -14,7 +13,6 @@
         <app-text-input
           [label]="'People'"
           [icon]="'bi-person-fill'"
-          [placeholder]="'0'"
           [control]="youthRateGroupsAttendancePeopleField"
           [type]="'number'"
         ></app-text-input>

--- a/src/app/shared/components/forms/text-input/text-input.component.html
+++ b/src/app/shared/components/forms/text-input/text-input.component.html
@@ -53,7 +53,7 @@
     id="{{ id }}"
     class="form-control text-end"
     [formControl]="control"
-    placeholder="0.00"
+    placeholder="{{ placeholder }}"
     min="0.01"
     step="0.01"
     attr.aria-label="{{ ariaLabel }}"

--- a/src/app/shared/components/forms/text-input/text-input.component.ts
+++ b/src/app/shared/components/forms/text-input/text-input.component.ts
@@ -11,7 +11,7 @@ export class TextInputComponent implements OnInit {
   @Input() control = new FormControl;
   @Input() label;
   @Input() icon;
-  @Input() placeholder;
+  @Input() placeholder = "No data";
   @Input() id;
   @Input() ariaLabel;
   @Input() ariaDescribedBy;


### PR DESCRIPTION
### Jira Ticket:
NOBUG

GH Issue #68  

### Description:
This change removes `0` from all form placeholders to mitigate confusion over what is `null` and what is actually `0`.  The default empty field placeholder is currently set to read `No data` as a clear indicator the field is empty, but this can easily be changed to something more appropriate in the future. Hyphens `-` are used elsewhere in the code to denote empty fields but still feel unclear when used as placeholders in editable fields. Leaving empty fields 'blank' also makes it difficult to understand the field is editable at a quick glance. 