### PR TITLE
112: consolidating subscriptions to mitigate memory leaks

### DIFF
--- a/src/app/enter-data/accordion-manager/accordion-manager.component.ts
+++ b/src/app/enter-data/accordion-manager/accordion-manager.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { Constants } from 'src/app/shared/utils/constants';
 
@@ -12,18 +12,18 @@ export class AccordionManagerComponent implements OnDestroy {
   public icons = Constants.iconUrls;
 
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
   public subAreaData;
 
   private mappedAccordionItems = {
-      'collapsefrontcountryCamping': 'frontcountryCamping',
-      'collapsefrontcountryCabins': 'frontcountryCabins',
-      'collapsegroupCamping': 'groupCamping',
-      'collapsedayuse': 'dayuse',
-      'collapsebackcountryCamping': 'backcountryCamping',
-      'collapsebackcountryCabins':'backcountryCabins',
-      'collapseboating': 'boating',
-    };
+    collapsefrontcountryCamping: 'frontcountryCamping',
+    collapsefrontcountryCabins: 'frontcountryCabins',
+    collapsegroupCamping: 'groupCamping',
+    collapsedayuse: 'dayuse',
+    collapsebackcountryCamping: 'backcountryCamping',
+    collapsebackcountryCabins: 'backcountryCabins',
+    collapseboating: 'boating',
+  };
 
   public accordions = {
     frontcountryCamping: false,
@@ -36,7 +36,7 @@ export class AccordionManagerComponent implements OnDestroy {
   };
 
   constructor(protected dataService: DataService) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       dataService
         .getItemValue(Constants.dataIds.ENTER_DATA_SUB_AREA)
         .pipe(takeWhile(() => this.alive))
@@ -55,17 +55,22 @@ export class AccordionManagerComponent implements OnDestroy {
       const keys = Object.keys(this.mappedAccordionItems);
       for (const key in keys) {
         // Don't touch the one we are actively getting clicked on
-        if (this.mappedAccordionItems[keys[key]] !== this.mappedAccordionItems[currentId]) {
-            let item = document.getElementById(keys[key]);
-            let clickEvent = new Event('click');
+        if (
+          this.mappedAccordionItems[keys[key]] !==
+          this.mappedAccordionItems[currentId]
+        ) {
+          let item = document.getElementById(keys[key]);
+          let clickEvent = new Event('click');
 
-            // Check if it's open.
-            if (item && item.classList.contains('show')) {
-              let hideItem = document.getElementById(this.mappedAccordionItems[keys[key]])?.firstChild;
-              if (hideItem) {
-                hideItem.dispatchEvent(clickEvent);
-              }
+          // Check if it's open.
+          if (item && item.classList.contains('show')) {
+            let hideItem = document.getElementById(
+              this.mappedAccordionItems[keys[key]]
+            )?.firstChild;
+            if (hideItem) {
+              hideItem.dispatchEvent(clickEvent);
             }
+          }
         }
       }
     }
@@ -84,13 +89,15 @@ export class AccordionManagerComponent implements OnDestroy {
 
     const keys = Object.keys(this.mappedAccordionItems);
     for (const key in keys) {
-        let item = document.getElementById(keys[key]);
-        let clickEvent = new Event('click');
-        // Check if it's open.
-        if (item && item.classList.contains('show')) {
-          let hideItem = document.getElementById(this.mappedAccordionItems[keys[key]])?.firstChild;
-          if (hideItem) {
-            hideItem.dispatchEvent(clickEvent);
+      let item = document.getElementById(keys[key]);
+      let clickEvent = new Event('click');
+      // Check if it's open.
+      if (item && item.classList.contains('show')) {
+        let hideItem = document.getElementById(
+          this.mappedAccordionItems[keys[key]]
+        )?.firstChild;
+        if (hideItem) {
+          hideItem.dispatchEvent(clickEvent);
         }
       }
     }
@@ -129,8 +136,6 @@ export class AccordionManagerComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/backcountry-cabins-accordion/backcountry-cabins-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/backcountry-cabins-accordion/backcountry-cabins-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class BackcountryCabinsAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class BackcountryCabinsAccordionComponent implements OnDestroy {
     protected dataService: DataService,
     protected formulaService: FormulaService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CABINS)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CABINS)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -70,8 +72,6 @@ export class BackcountryCabinsAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class BackcountryCampingAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class BackcountryCampingAccordionComponent implements OnDestroy {
     protected dataService: DataService,
     protected formulaService: FormulaService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -56,8 +58,6 @@ export class BackcountryCampingAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class BoatingAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class BoatingAccordionComponent implements OnDestroy {
     protected dataService: DataService,
     protected formulaService: FormulaService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_BOATING)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_BOATING)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -73,8 +75,6 @@ export class BoatingAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/day-use-accordion/day-use-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/day-use-accordion/day-use-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class DayUseAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class DayUseAccordionComponent implements OnDestroy {
     private formulaService: FormulaService,
     protected dataService: DataService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_DAY_USE)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_DAY_USE)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -99,8 +101,6 @@ export class DayUseAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class FrontcountryCabinsAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class FrontcountryCabinsAccordionComponent implements OnDestroy {
     protected dataService: DataService,
     protected formulaService: FormulaService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -57,8 +59,6 @@ export class FrontcountryCabinsAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class FrontcountryCampingAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class FrontcountryCampingAccordionComponent implements OnDestroy {
     protected dataService: DataService,
     protected formulaService: FormulaService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CAMPING)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CAMPING)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -136,8 +138,6 @@ export class FrontcountryCampingAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { FormulaService } from 'src/app/services/formula.service';
 import { summarySection } from 'src/app/shared/components/accordion/summary-section/summary-section.component';
@@ -12,7 +12,7 @@ import { Constants } from 'src/app/shared/utils/constants';
 })
 export class GroupCampingAccordionComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public icons = Constants.iconUrls;
   public data;
@@ -22,13 +22,15 @@ export class GroupCampingAccordionComponent implements OnDestroy {
     protected dataService: DataService,
     protected formulaService: FormulaService
   ) {
-    dataService
-      .getItemValue(Constants.dataIds.ACCORDION_GROUP_CAMPING)
-      .pipe(takeWhile(() => this.alive))
-      .subscribe((res) => {
-        this.data = res;
-        this.buildAccordion();
-      });
+    this.subscriptions.add(
+      dataService
+        .getItemValue(Constants.dataIds.ACCORDION_GROUP_CAMPING)
+        .pipe(takeWhile(() => this.alive))
+        .subscribe((res) => {
+          this.data = res;
+          this.buildAccordion();
+        })
+    );
   }
 
   buildAccordion() {
@@ -99,8 +101,6 @@ export class GroupCampingAccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/enter-data.component.ts
+++ b/src/app/enter-data/enter-data.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { filter, takeWhile } from 'rxjs';
+import { filter, Subscription, takeWhile } from 'rxjs';
 import { DataService } from '../services/data.service';
 import { Constants } from '../shared/utils/constants';
 import { Utils } from '../shared/utils/utils';
@@ -12,7 +12,7 @@ import { Utils } from '../shared/utils/utils';
 })
 export class EnterDataComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
   public subAreaData;
 
   public onChildRoute = false;
@@ -24,7 +24,7 @@ export class EnterDataComponent implements OnDestroy {
   the date and location you want to view.`;
 
   constructor(protected dataService: DataService, protected router: Router) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       dataService
         .getItemValue(Constants.dataIds.ENTER_DATA_SUB_AREA)
         .pipe(takeWhile(() => this.alive))
@@ -33,7 +33,7 @@ export class EnterDataComponent implements OnDestroy {
         })
     );
 
-    this.subscriptions.push(
+    this.subscriptions.add(
       router.events
         .pipe(filter((event) => event instanceof NavigationEnd))
         .pipe(takeWhile(() => this.alive))
@@ -43,7 +43,7 @@ export class EnterDataComponent implements OnDestroy {
         })
     );
 
-    this.subscriptions.push(
+    this.subscriptions.add(
       dataService
         .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .pipe(takeWhile(() => this.alive))
@@ -57,8 +57,6 @@ export class EnterDataComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/enter-data/sub-area-search/sub-area-search.component.ts
+++ b/src/app/enter-data/sub-area-search/sub-area-search.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, ViewChild } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { SubAreaService } from 'src/app/services/sub-area.service';
 import { TypeaheadComponent } from 'src/app/shared/components/typeahead/typeahead.component';
@@ -17,7 +17,7 @@ export class SubAreaSearchComponent implements OnDestroy {
   @ViewChild(TypeaheadComponent) typeAhead: TypeaheadComponent;
 
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
   private utils = new Utils();
   private dataPreloaded = false;
 
@@ -43,7 +43,7 @@ export class SubAreaSearchComponent implements OnDestroy {
     private activatedRoute: ActivatedRoute,
     private formService: FormService
   ) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       dataService
         .getItemValue(Constants.dataIds.ENTER_DATA_PARK)
         .pipe(takeWhile(() => this.alive))
@@ -198,8 +198,6 @@ export class SubAreaSearchComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/forms/backcountry-cabins/backcountry-cabins.component.ts
+++ b/src/app/forms/backcountry-cabins/backcountry-cabins.component.ts
@@ -50,7 +50,7 @@ export class BackcountryCabinsComponent extends BaseFormComponent {
     );
 
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CABINS)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/forms/backcountry-camping/backcountry-camping.component.ts
+++ b/src/app/forms/backcountry-camping/backcountry-camping.component.ts
@@ -49,7 +49,7 @@ export class BackcountryCampingComponent extends BaseFormComponent {
     );
     
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/forms/boating/boating.component.ts
+++ b/src/app/forms/boating/boating.component.ts
@@ -49,7 +49,7 @@ export class BoatingComponent extends BaseFormComponent {
       changeDetectior
     );
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_BOATING)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/forms/day-use/day-use.component.ts
+++ b/src/app/forms/day-use/day-use.component.ts
@@ -50,7 +50,7 @@ export class DayUseComponent extends BaseFormComponent {
       changeDetectior
     );
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_DAY_USE)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/forms/frontcountry-cabins/frontcountry-cabins.component.ts
+++ b/src/app/forms/frontcountry-cabins/frontcountry-cabins.component.ts
@@ -48,7 +48,7 @@ export class FrontcountryCabinsComponent extends BaseFormComponent {
       changeDetectior
     );
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/forms/frontcountry-camping/frontcountry-camping.component.ts
+++ b/src/app/forms/frontcountry-camping/frontcountry-camping.component.ts
@@ -52,7 +52,7 @@ export class FrontcountryCampingComponent extends BaseFormComponent {
       changeDetectior
     );
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CAMPING)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/forms/group-camping/group-camping.component.ts
+++ b/src/app/forms/group-camping/group-camping.component.ts
@@ -46,7 +46,7 @@ export class GroupCampingComponent extends BaseFormComponent {
       changeDetectior
     );
     // push existing form data to parent subscriptions
-    this.subscriptions.push(
+    this.subscriptions.add(
       this.dataService
         .getItemValue(Constants.dataIds.ACCORDION_GROUP_CAMPING)
         .pipe(takeWhile(() => this.alive))

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router, Event } from '@angular/router';
-import { filter, takeWhile } from 'rxjs';
+import { filter, Subscription, takeWhile } from 'rxjs';
 import { ConfigService } from '../services/config.service';
 import { KeycloakService } from '../services/keycloak.service';
 
@@ -10,7 +10,7 @@ import { KeycloakService } from '../services/keycloak.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnDestroy {
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
   private alive = true;
 
   public envName: string;
@@ -30,7 +30,7 @@ export class HeaderComponent implements OnDestroy {
       return obj.path !== '**' && obj.path !== 'unauthorized';
     });
 
-    this.subscriptions.push(
+    this.subscriptions.add(
       router.events
         .pipe(filter((event) => event instanceof NavigationEnd))
         .pipe(takeWhile(() => this.alive))
@@ -50,8 +50,6 @@ export class HeaderComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/shared/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/accordion/accordion.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { DataService } from 'src/app/services/data.service';
 import { Constants } from '../../utils/constants';
 import { summarySection } from './summary-section/summary-section.component';
@@ -20,7 +20,7 @@ export class AccordionComponent implements OnDestroy {
   @Input() editLink: string = '';
 
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   private formParams;
 
@@ -31,7 +31,7 @@ export class AccordionComponent implements OnDestroy {
     private activatedRoute: ActivatedRoute,
     protected dataService: DataService
   ) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       dataService
         .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .pipe(takeWhile(() => this.alive))
@@ -52,8 +52,6 @@ export class AccordionComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/shared/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/components/breadcrumb/breadcrumb.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { BreadcrumbService } from 'src/app/services/breadcrumb.service';
 import { DataService } from 'src/app/services/data.service';
 import { Constants } from '../../utils/constants';
@@ -12,7 +12,7 @@ import { Constants } from '../../utils/constants';
 })
 export class BreadcrumbComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
   private enterDataUrlParams;
 
   public currentNavigation: any;
@@ -26,7 +26,7 @@ export class BreadcrumbComponent implements OnDestroy {
     protected breadcrumbService: BreadcrumbService,
     protected dataService: DataService
   ) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       breadcrumbService.breadcrumbs
         .pipe(takeWhile(() => this.alive))
         .subscribe((res) => {
@@ -38,7 +38,9 @@ export class BreadcrumbComponent implements OnDestroy {
               url: '',
             });
           }
-        }),
+        })
+    );
+      this.subscriptions.add(
       dataService
         .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .pipe(takeWhile(() => this.alive))
@@ -63,8 +65,6 @@ export class BreadcrumbComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/shared/components/date-picker/date-picker.component.ts
+++ b/src/app/shared/components/date-picker/date-picker.component.ts
@@ -12,6 +12,7 @@ import { NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import { FormControl } from '@angular/forms';
 import { Utils } from '../../utils/utils';
 import { takeWhile } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-date-picker',
@@ -28,7 +29,7 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
   @Input() required = false;
 
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public ngbDate: NgbDateStruct = null as any;
   public minNgbDate: NgbDateStruct = null as any;
@@ -59,7 +60,7 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit() {
     this.ngbDate = this.control.value || null;
     if (this.reset) {
-      this.subscriptions.push(
+      this.subscriptions.add(
         this.reset
           .pipe(takeWhile(() => this.alive))
           .subscribe(() => this.clearDate())
@@ -90,8 +91,6 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/shared/components/infinite-loading-bar/infinite-loading-bar.component.ts
+++ b/src/app/shared/components/infinite-loading-bar/infinite-loading-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
@@ -9,12 +9,12 @@ import { LoadingService } from 'src/app/services/loading.service';
 })
 export class InfiniteLoadingBarComponent implements OnDestroy {
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public loading = false;
 
   constructor(protected loadingService: LoadingService) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       loadingService
         .getLoadingStatus()
         .pipe(takeWhile(() => this.alive))
@@ -26,8 +26,6 @@ export class InfiniteLoadingBarComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -4,6 +4,7 @@ import { SideBarService } from 'src/app/services/sidebar.service';
 import { Router, Event, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/internal/operators/filter';
 import { SubAreaService } from 'src/app/services/sub-area.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-sidebar',
@@ -19,7 +20,7 @@ export class SidebarComponent implements OnDestroy {
 
   private alive = true;
 
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   constructor(
     protected sideBarService: SideBarService,
@@ -30,7 +31,7 @@ export class SidebarComponent implements OnDestroy {
       return obj.path !== '**' && obj.path !== 'unauthorized';
     });
 
-    this.subscriptions.push(
+    this.subscriptions.add(
       router.events
         .pipe(filter((event) => event instanceof NavigationEnd))
         .pipe(takeWhile(() => this.alive))
@@ -39,7 +40,7 @@ export class SidebarComponent implements OnDestroy {
         })
     );
 
-    this.subscriptions.push(
+    this.subscriptions.add(
       sideBarService.toggleChange
         .pipe(takeWhile(() => this.alive))
         .subscribe((hide) => {
@@ -61,9 +62,7 @@ export class SidebarComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 
   getPathFromUrl(url) {

--- a/src/app/shared/components/text-to-loading-spinner/text-to-loading-spinner.component.ts
+++ b/src/app/shared/components/text-to-loading-spinner/text-to-loading-spinner.component.ts
@@ -5,7 +5,7 @@ import {
   OnDestroy,
   Output,
 } from '@angular/core';
-import { takeWhile } from 'rxjs';
+import { Subscription, takeWhile } from 'rxjs';
 import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
@@ -18,12 +18,12 @@ export class TextToLoadingSpinnerComponent implements OnDestroy {
   @Output() loadingStatus: EventEmitter<boolean> = new EventEmitter();
 
   private alive = true;
-  private subscriptions: any[] = [];
+  private subscriptions = new Subscription();
 
   public loading = false;
 
   constructor(protected loadingService: LoadingService) {
-    this.subscriptions.push(
+    this.subscriptions.add(
       loadingService
         .getLoadingStatus()
         .pipe(takeWhile(() => this.alive))
@@ -36,8 +36,6 @@ export class TextToLoadingSpinnerComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.alive = false;
-    for (let i = 0; i < this.subscriptions.length; i++) {
-      this.subscriptions[i].unsubscribe();
-    }
+    this.subscriptions.unsubscribe();
   }
 }


### PR DESCRIPTION
### GitHub Issue:
#112 

### Description:
Changing subscriptions from an array-based model to a single `Subscription` object per component. Instead of iterating through an array of subscriptions and unsubscribing to each one, new subscriptions are added to the `Subscription` object using `Subscription.add()`. When the component is destroyed, calling `Subscription.unsubscribe()` terminates all subs simultaneously without iteration. 