### PR TITLE
103: block hyphens in currency fields

### DIFF
--- a/src/app/shared/components/forms/base-form/base-form.component.ts
+++ b/src/app/shared/components/forms/base-form/base-form.component.ts
@@ -200,7 +200,6 @@ export class BaseFormComponent implements AfterViewChecked, OnDestroy {
       payload: payload,
       invalidFields: this.getInvalidFields(),
     };
-
     return fResult;
   }
 

--- a/src/app/shared/components/forms/text-input/text-input.component.ts
+++ b/src/app/shared/components/forms/text-input/text-input.component.ts
@@ -8,10 +8,10 @@ import { FormControl } from '@angular/forms';
 })
 export class TextInputComponent implements OnInit {
   @Input() type = 'text'; // text, number
-  @Input() control = new FormControl;
+  @Input() control = new FormControl();
   @Input() label;
   @Input() icon;
-  @Input() placeholder = "No data";
+  @Input() placeholder = 'No data';
   @Input() id;
   @Input() ariaLabel;
   @Input() ariaDescribedBy;
@@ -21,10 +21,9 @@ export class TextInputComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  blockInvalidChars(e){
-    if (e.key === 'e' || e.key === 'E') {
+  blockInvalidChars(e) {
+    if (e.key === 'e' || e.key === 'E' || e.key === '-') {
       e.preventDefault();
     }
   }
-
 }


### PR DESCRIPTION
### GitHub Issue:
#103 

### Description:
Blocking the use of hyphens in currency fields to prevent negative/null values in these fields. This is a quick workaround to #103 under the assumption that the term 'revenue' indicates that the values in these currency fields will always be positive. Issue #103 should probably remain open for now as this does not solve it.