### PR TITLE
BRS-653: A&R Login Page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,6 +12,7 @@ import { GroupCampingComponent } from './forms/group-camping/group-camping.compo
 import { AuthGuard } from './guards/auth.guard';
 import { HomeComponent } from './home/home.component';
 import { NotAuthorizedComponent } from './not-authorized/not-authorized.component';
+import { LoginComponent } from './login/login.component';
 import { ExportResolver } from './resolvers/export.resolver';
 import { FormResolver } from './resolvers/form.resolver';
 import { SubAreaResolver } from './resolvers/sub-area.resolver';
@@ -129,6 +130,19 @@ const routes: Routes = [
     path: 'unauthorized',
     pathMatch: 'full',
     component: NotAuthorizedComponent,
+    data: {
+      showSideBar: false,
+      showBreadCrumb: false,
+    },
+  },
+  {
+    path: 'login',
+    pathMatch: 'full',
+    component: LoginComponent,
+    data: {
+      showSideBar: false,
+      showBreadCrumb: false,
+    },
   },
   {
     // wildcard route

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,14 +1,17 @@
 <div class="box">
   <div class="header">
-    <app-header></app-header>
+    <app-header [showSideBar]="showSideBar"></app-header>
     <app-infinite-loading-bar></app-infinite-loading-bar>
   </div>
   <div class="content" fxFlex fxLayout="column">
     <div class="wrapper h-100">
-      <app-sidebar class="d-none d-lg-inline"></app-sidebar>
+      <app-sidebar *ngIf="showSideBar" class="d-none d-lg-inline"></app-sidebar>
       <div class="content">
-        <app-toggle-button class="d-none d-lg-inline"></app-toggle-button>
-        <app-breadcrumb></app-breadcrumb>
+        <app-toggle-button
+          *ngIf="showSideBar"
+          class="d-none d-lg-inline"
+        ></app-toggle-button>
+        <app-breadcrumb *ngIf="showBreadCrumb"></app-breadcrumb>
         <router-outlet></router-outlet>
       </div>
     </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { Subscription } from 'rxjs';
 import { ToastService } from './services/toast.service';
@@ -9,15 +10,31 @@ import { Constants } from './shared/utils/constants';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnDestroy {
+export class AppComponent implements OnInit, OnDestroy {
   title = 'attendance-and-revanue-admin';
   toastSubscription: Subscription;
+  showSideBar = false;
+  showBreadCrumb = false;
 
   constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
     private toastr: ToastrService,
     private toastService: ToastService
   ) {
     this.watchForToast();
+  }
+
+  ngOnInit() {
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        if (this.activatedRoute && this.activatedRoute.firstChild) {
+          const routeData = this.activatedRoute.firstChild.snapshot.data;
+          this.showSideBar = routeData['showSideBar'] !== false;
+          this.showBreadCrumb = routeData['showBreadCrumb'] !== false;
+        }
+      }
+    });
   }
 
   private watchForToast() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { HomeModule } from './home/home.module';
 import { KeycloakService } from './services/keycloak.service';
 import { TokenInterceptor } from './shared/utils/token-interceptor';
 import { NotAuthorizedComponent } from './not-authorized/not-authorized.component';
+import { LoginComponent } from './login/login.component';
 import { ApiService } from './services/api.service';
 import { AutoFetchService } from './services/auto-fetch.service';
 import { InfiniteLoadingBarModule } from './shared/components/infinite-loading-bar/infinite-loading-bar.module';
@@ -43,7 +44,7 @@ export function initConfig(
 }
 
 @NgModule({
-  declarations: [AppComponent, NotAuthorizedComponent],
+  declarations: [AppComponent, NotAuthorizedComponent, LoginComponent],
   imports: [
     BrowserModule,
     CommonModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,7 +39,9 @@ export function initConfig(
     await configService.init();
     apiService.init();
     await keycloakService.init();
-    autoFetchService.run();
+    if (keycloakService.isAuthorized()) {
+      autoFetchService.run();
+    }
   };
 }
 

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -8,6 +8,9 @@ import { AuthGuard } from './auth.guard';
 describe('AuthGuard', () => {
   const mockKeycloakService = jasmine.createSpyObj('KeycloakService', [
     'isAuthenticated',
+    'isAuthorized',
+    'getIdpFromToken',
+    'login',
   ]);
   const mockRouter = jasmine.createSpyObj('Router', ['parseUrl']);
 
@@ -33,6 +36,7 @@ describe('AuthGuard', () => {
 
   it('should return true if the user is authenticated', () => {
     mockKeycloakService.isAuthenticated.and.returnValue(true);
+    mockKeycloakService.isAuthorized.and.returnValue(true);
 
     const guard = TestBed.get(AuthGuard);
 
@@ -41,11 +45,44 @@ describe('AuthGuard', () => {
     expect(result).toEqual(true);
   });
 
-  it('should return redirect to unauthorized page if the user is not authenticated', () => {
+  it('should return redirect to login page if the user is not authenticated and sessionStorage does not contain an idp value', () => {
     const routerMock = TestBed.get(Router);
     routerMock.parseUrl.calls.reset();
 
     mockKeycloakService.isAuthenticated.and.returnValue(false);
+
+    spyOn(window.sessionStorage, 'getItem').and.callFake(() => {
+      return null;
+    });
+
+    const guard = TestBed.get(AuthGuard);
+    guard.canActivate();
+
+    expect(routerMock.parseUrl).toHaveBeenCalledWith('/login');
+  });
+
+  it('should return redirect to login page if the user is not authenticated and sessionStorage contains an idp value', () => {
+    const routerMock = TestBed.get(Router);
+    routerMock.parseUrl.calls.reset();
+
+    mockKeycloakService.isAuthenticated.and.returnValue(false);
+
+    spyOn(window.sessionStorage, 'getItem').and.callFake(() => {
+      return 'idir';
+    });
+
+    const guard = TestBed.get(AuthGuard);
+    guard.canActivate();
+
+    expect(mockKeycloakService.login).toHaveBeenCalled();
+  });
+
+  it('should return redirect to unauthorized page if the user is not authorized', () => {
+    const routerMock = TestBed.get(Router);
+    routerMock.parseUrl.calls.reset();
+
+    mockKeycloakService.isAuthenticated.and.returnValue(true);
+    mockKeycloakService.isAuthorized.and.returnValue(false);
 
     const guard = TestBed.get(AuthGuard);
     guard.canActivate();

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -11,11 +11,49 @@ export class AuthGuard implements CanActivate {
     private readonly router: Router
   ) {}
 
-  canActivate(): true | UrlTree {
-    if (this.keycloakService.isAuthenticated()) {
-      return true;
+  canActivate(): boolean | UrlTree {
+    // When a successful login occurs, we store the identity provider used in sessionStorage.
+    const lastIdp = sessionStorage.getItem(
+      this.keycloakService.LAST_IDP_AUTHENTICATED
+    );
+
+    // Not authenticated
+    if (!this.keycloakService.isAuthenticated()) {
+      if (lastIdp === null) {
+        // If an identity provider hasn't been selected then show the login page.
+        return this.router.parseUrl('/login');
+      }
+      // If an identity provider was already selected and successfully authenticated
+      // then do a keycloak login with that identity provider.
+
+      // remove the sessionStorage value first, so if this authentication attempt
+      // fails then the user will get the login page next time.
+      sessionStorage.removeItem(this.keycloakService.LAST_IDP_AUTHENTICATED);
+
+      // log in using the last identity provider that worked
+      this.keycloakService.login(lastIdp);
+      return false;
     }
 
-    return this.router.parseUrl('/unauthorized');
+    if (lastIdp === null) {
+      // Store the identity provider that was used to successfully log in.
+      // Even if the user is unauthorized, we still want to store this because
+      // we don't have a logout, so there is no point allowing the user to select
+      // a different IDP, as Keycloak will just ignore the selection when the user
+      // is authenticated already.
+      const idp = this.keycloakService.getIdpFromToken();
+      if (idp !== '') {
+        sessionStorage.setItem(this.keycloakService.LAST_IDP_AUTHENTICATED, idp);
+      }
+    }
+
+    // Not authorized
+    if (!this.keycloakService.isAuthorized()) {
+      // login was successful but the user doesn't have necessary Keycloak roles.
+      return this.router.parseUrl('/unauthorized');
+    }
+
+    // Show the requested page.
+    return true;
   }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -26,13 +26,14 @@
       <button
         class="navbar-toggler"
         type="button"
+        *ngIf="showSideBar"
         (click)="isMenuCollapsed = !isMenuCollapsed"
       >
         &#9776;
       </button>
       <div class="d-none d-lg-inline">
         <div class="me-auto"></div>
-        <div *ngIf="isAuthenticated" class="navbar-text me-3">
+        <div *ngIf="isAuthorized" class="navbar-text me-3">
           {{ welcomeMsg }}
         </div>
       </div>
@@ -53,7 +54,7 @@
         >
           <a [routerLink]="[route.path]">{{ route.data.label }}</a>
         </li>
-        <div *ngIf="isAuthenticated" class="navbar-text welcome-text p-2">
+        <div *ngIf="isAuthorized" class="navbar-text welcome-text p-2">
           {{ welcomeMsg }}
         </div>
       </ul>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router, Event } from '@angular/router';
 import { filter, Subscription } from 'rxjs';
 import { ConfigService } from '../services/config.service';
@@ -10,12 +10,14 @@ import { KeycloakService } from '../services/keycloak.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnDestroy {
+  @Input() showSideBar = true;
+  
   private subscriptions = new Subscription();
 
   public envName: string;
   public showBanner = true;
   public welcomeMsg: String;
-  public isAuthenticated: boolean;
+  public isAuthorized: boolean;
   public isMenuCollapsed = true;
   public routes: any[] = [];
   public currentRoute: any;
@@ -37,7 +39,7 @@ export class HeaderComponent implements OnDestroy {
         })
     );
 
-    this.isAuthenticated = this.keycloakService.isAuthenticated();
+    this.isAuthorized = this.keycloakService.isAuthorized();
     this.welcomeMsg = this.keycloakService.getWelcomeMessage();
 
     this.envName = this.configService.config['ENVIRONMENT'];

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,0 +1,53 @@
+<div class="login-container d-md-flex justify-content-center pt-md-5">
+<div class="login-form p-2 p-md-4">
+  <div class="content text-center">
+    <h1>Attendance &amp; Revenue</h1>
+    <p>
+      Select the ID you want to use to log into the Attendance &amp; Revenue system.
+    </p>
+    <p>
+      <button
+        type="button"
+        (click)="handleLogin(keycloakService.idpHintEnum.BCSC)"
+        class="btn btn-login"
+      >
+        Log in with BC Services Card
+      </button>
+      <br />
+      <a
+        href="https://www2.gov.bc.ca/gov/content/governments/government-id/bcservicescardapp/setup"
+        class="reg-link"
+        target="_blank"
+      >
+        <i class="bi bi-box-arrow-up-right"></i>Set up the BC Services Card App
+      </a>
+    </p>
+    <p>
+      <button
+        type="button"
+        (click)="handleLogin(keycloakService.idpHintEnum.BCEID)"
+        class="btn btn-login"
+      >
+        Log in with BCeID
+      </button>
+      <br />
+      <a
+        href="https://www.bceid.ca/directories/bluepages/details.aspx?serviceId=7852&eServiceType=all"
+        class="reg-link"
+        target="_blank"
+      >
+        <i class="bi bi-box-arrow-up-right"></i>Register for a BCeID
+      </a>
+    </p>
+    <p>
+      <button
+        type="button"
+        (click)="handleLogin(keycloakService.idpHintEnum.IDIR)"
+        class="btn btn-login"
+      >
+        Log in with IDIR
+      </button>
+    </p>
+  </div>
+</div>
+</div>

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -1,8 +1,14 @@
 @import "src/assets/themes/variables";
 
+h1 {
+  font-size: 2.8rem;
+  font-weight: normal;
+}
+
 .login-container {
   background-color: $white;
   min-height: 100%;
+  padding: 1.4rem 0.6rem;
 }
 
 .login-form {
@@ -14,6 +20,7 @@
 @media screen and (min-width: 768px) {
   .login-container {
     background: $form-grey;
+    padding: 0;
   }
   .login-form {
     border: 1px solid $alpha-border-color;

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -1,0 +1,49 @@
+@import "src/assets/themes/variables";
+
+.login-container {
+  background-color: $white;
+  min-height: 100%;
+}
+
+.login-form {
+  background: $white;
+  max-width: 50rem;
+  height: fit-content;
+}
+
+@media screen and (min-width: 768px) {
+  .login-container {
+    background: $form-grey;
+  }
+  .login-form {
+    border: 1px solid $alpha-border-color;
+    width: 75%;
+  }
+}
+
+.btn-login {
+  background: $primary;
+  color: $white;
+  margin-top: 0.75rem;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.btn-login,
+a.reg-link {
+  width: 18rem;
+  max-width: 100%;
+}
+
+a.reg-link {
+  text-align: left;
+  margin-bottom: 0.5rem;
+  display: inline-block;
+  margin-top: 0.25rem;
+
+  i {
+    margin-right: 0.25rem;
+  }
+}

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { KeycloakService } from '../services/keycloak.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss']
+})
+export class LoginComponent implements OnInit {
+  constructor(public keycloakService: KeycloakService, private router: Router) {}
+
+  ngOnInit() {
+    if (this.keycloakService.isAuthenticated()) {
+      if (this.keycloakService.isAuthorized()) {
+        this.router.navigate(['/']);
+        return;
+      } else {
+        this.router.navigate(['/unauthorized']);
+        return;
+      }
+    }
+  }
+
+  handleLogin(idpHint: string) {
+    this.keycloakService.login(idpHint);
+  }
+}

--- a/src/app/not-authorized/not-authorized.component.html
+++ b/src/app/not-authorized/not-authorized.component.html
@@ -1,6 +1,10 @@
 <div class="container-fluid">
-  <div>
+  <div class="p-2 pt-4">
     <h1>Unauthorized</h1>
     <p>You do not have permissions to view this page.</p>
+    <p>
+      Please contact BC Parks Digital Services to get the correct permissions.
+      To try a different login account, shut down and restart your browser.
+    </p>
   </div>
 </div>

--- a/src/app/not-authorized/not-authorized.component.spec.ts
+++ b/src/app/not-authorized/not-authorized.component.spec.ts
@@ -1,4 +1,8 @@
+import { HttpClient, HttpHandler } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ConfigService } from '../services/config.service';
+import { KeycloakService } from '../services/keycloak.service';
 
 import { NotAuthorizedComponent } from './not-authorized.component';
 
@@ -8,9 +12,10 @@ describe('NotAuthorizedComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ NotAuthorizedComponent ]
-    })
-    .compileComponents();
+      imports: [RouterTestingModule],
+      declarations: [NotAuthorizedComponent],
+      providers: [KeycloakService, ConfigService, HttpClient, HttpHandler],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/not-authorized/not-authorized.component.ts
+++ b/src/app/not-authorized/not-authorized.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { KeycloakService } from '../services/keycloak.service';
 
 @Component({
   selector: 'app-not-authorized',
@@ -6,10 +8,21 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./not-authorized.component.scss']
 })
 export class NotAuthorizedComponent implements OnInit {
+  constructor(
+    private router: Router,
+    private keycloakService: KeycloakService
+  ) {}
 
-  constructor() { }
-
-  ngOnInit(): void {
+  ngOnInit() {
+    if (this.keycloakService.isAuthenticated()) {
+      if (this.keycloakService.isAuthorized()) {
+        this.router.navigate(['/']);
+        return;
+      }
+    } else {
+      this.router.navigate(['/login']);
+      return;
+    }
   }
 
 }

--- a/src/app/services/keycloak.service.spec.ts
+++ b/src/app/services/keycloak.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { KeycloakService } from './keycloak.service';
+import { ConfigService } from './config.service';
+import { LoggerService } from './logger.service';
+import { ToastService } from './toast.service';
+import { JwtUtil } from '../shared/utils/jwt-utils';
+
+describe('KeycloakService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        KeycloakService,
+        ConfigService,
+        LoggerService,
+        ToastService,
+        HttpClient,
+        HttpHandler,
+      ],
+    });
+  });
+
+  it('idp should be `idir` if the token has an idir_userid property', () => {
+    spyOn(JwtUtil, 'decodeToken').and.callFake(() => {
+      return {
+        idir_userid: '12345',
+      };
+    });
+    const keycloak = TestBed.get(KeycloakService);
+    spyOn(keycloak, 'getToken').and.callFake(() => {
+      return 'not-empty';
+    });
+    const idp = keycloak.getIdpFromToken();
+    expect(idp).toEqual('idir');
+  });
+
+  it('idp should be `bceid-basic-and-business` if the token has an bceid_userid property', () => {
+    spyOn(JwtUtil, 'decodeToken').and.callFake(() => {
+      return {
+        bceid_userid: '12345',
+      };
+    });
+    const keycloak = TestBed.get(KeycloakService);
+    spyOn(keycloak, 'getToken').and.callFake(() => {
+      return 'not-empty';
+    });
+    const idp = keycloak.getIdpFromToken();
+    expect(idp).toEqual('bceid-basic-and-business');
+  });
+
+  it('idp should be `bcsc` if the token does not match any known patterns', () => {
+    spyOn(JwtUtil, 'decodeToken').and.callFake(() => {
+      return {
+        preferred_username: 'abc',
+      };
+    });
+    const keycloak = TestBed.get(KeycloakService);
+    spyOn(keycloak, 'getToken').and.callFake(() => {
+      return 'not-empty';
+    });
+    const idp = keycloak.getIdpFromToken();
+    expect(idp).toEqual('bcsc');
+  });
+});


### PR DESCRIPTION
### Jira Ticket:
BRS-653

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-653

### Description:
- Added a custom login page for Attendance and Revenue
- Changed the existing Not Authorized page to use a single column layout (similar to the new login page)
- Infers the selected Identity Provider from the JWT token after successful log in and stores it in sessionStorage so future login requests to Keycloak will use the same IDP, even if the application is reloaded and its state is lost.
