### PR TITLE
BRS-653: Update the BCeID registration url (was set to the DUP url)

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -32,7 +32,7 @@
       </button>
       <br />
       <a
-        href="https://www.bceid.ca/directories/bluepages/details.aspx?serviceId=7852&eServiceType=all"
+        href="https://www.bceid.ca/directories/bluepages/details.aspx?serviceId=7851&eServiceType=all"
         class="reg-link"
         target="_blank"
       >


### PR DESCRIPTION
### Jira Ticket:
BRS-653

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-653

### Description:
Updated the URL for A&R BCeID registration based on bug found by QA.  
The wrong URL was copied/pasted from Day Use Pass.  