### PR TITLE
NOBUG updating Actions to use Node16

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -18,7 +18,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -40,7 +40,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -63,7 +63,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -113,7 +113,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -169,7 +169,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -21,7 +21,7 @@ jobs:
     environment: prod
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -75,7 +75,7 @@ jobs:
     environment: prod
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -21,7 +21,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -76,7 +76,7 @@ jobs:
     environment: test
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr-linting.yaml
+++ b/.github/workflows/pr-linting.yaml
@@ -9,7 +9,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     environment: dev
     strategy:
       matrix:
-        node: ['14']
+        node: ['16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
### Jira Ticket:
NOBUG

### Description:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/