### PR TITLE
BRS-849 exporter error handling and retry limiting

### DIFF
--- a/src/app/resolvers/export.resolver.ts
+++ b/src/app/resolvers/export.resolver.ts
@@ -9,8 +9,6 @@ import { Constants } from '../shared/utils/constants';
 export class ExportResolver implements Resolve<void> {
   constructor(private exportService: ExportService) {}
   resolve() {
-    this.exportService.pollReportStatus(
-      Constants.dataIds.EXPORT_ALL_POLLING_DATA
-    );
+    this.exportService.checkForReports(Constants.dataIds.EXPORT_ALL_POLLING_DATA);
   }
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-849
### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-849

### Description:
Exporter would continually poll for results even if report generation had failed. It would poll until the jwt expired at around 15 minutes. This change implements some smarter error checking.

With the associated API changes in https://github.com/bcgov/bcparks-ar-api/pull/88, we can now more easily check the status of a currently running job (`jobObj.progressState`). The error state has been added to jobs so that the front end knows when to stop polling the back end for a result.

If the exporter runs into an error, it will reattempt report generation a fixed number of times before giving up. If no errors are encountered, it will poll the API for a fixed time until giving up. Values for error retry limits, timeouts, and polling rates are currently hard-coded and should probably be parametrized in a future version. 

If the exporter is unable to generate a report, the most recently generated successful report will still be available to download. 