### PR TITLE
BRS-870: Update package to use original terragrunt-github-action inst…

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -217,7 +217,7 @@ jobs:
           cli_config_credentials_token: ${{ secrets.TFC_TEAM_TOKEN }}
 
       - name: Setup terragrunt
-        uses: peter-murray/terragrunt-github-action@v1.0.0
+        uses: autero1/terragrunt-github-action@v1.0.0
         with:
           terragrunt_version: ${{ env.TG_VERSION }}
 


### PR DESCRIPTION
…ead of fork.

### Jira Ticket:
BRS-870

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-870

### Description:
This updates a package for our github action runner to be compatible with node 16.