### PR TITLE
BRS-972: Part I - revamping enter-data search

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,7 @@ module.exports = function (config) {
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
+      captureConsole: true,
       jasmine: {
         // you can add configuration options for Jasmine here
         // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
@@ -35,9 +36,8 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: false,
+    autoWatch: true,
     browsers: ['ChromeHeadless'],
-    singleRun: true,
     restartOnFileChange: true
   });
 };

--- a/src/app/enter-data/enter-data.component.ts
+++ b/src/app/enter-data/enter-data.component.ts
@@ -19,6 +19,9 @@ export class EnterDataComponent implements OnDestroy {
     parkName: '',
     subAreaName: '',
     date: '',
+    orcs: '',
+    subAreaId: '',
+    isLegacy: false,
   };
   public utils = new Utils();
 

--- a/src/app/enter-data/enter-data.module.ts
+++ b/src/app/enter-data/enter-data.module.ts
@@ -21,10 +21,12 @@ import { FrontcountryCampingModule } from '../forms/frontcountry-camping/frontco
 import { GroupCampingModule } from '../forms/group-camping/group-camping.module';
 import { FormService } from '../services/form.service';
 import { TextToLoadingSpinnerModule } from '../shared/components/text-to-loading-spinner/text-to-loading-spinner.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   declarations: [EnterDataComponent, SubAreaSearchComponent],
   imports: [
+    NgbModule,
     CommonModule,
     TypeaheadModule,
     InfoTextModule,

--- a/src/app/enter-data/sub-area-search/sub-area-search.component.html
+++ b/src/app/enter-data/sub-area-search/sub-area-search.component.html
@@ -12,29 +12,31 @@
         [maxDate]="maxDate"
         [bsConfig]="{ dateInputFormat: 'MM/YYYY' }"
         (onShown)="onOpenCalendar($event)"
-        (ngModelChange)="datePickerOutput($event)"
+        (ngModelChange)="dateChange($event)"
       />
     </div>
     <div class="col-sm-12 col-md-6 col-lg-3">
-      <app-typeahead
+      <!-- wait for controls to load before rendering typeaheads -->
+      <app-typeahead *ngIf="fields.park"
+        #parkTypeAhead
+        [control]="fields.park"
         [id]="'park-typeahead'"
-        [data]="parks['typeAheadData']"
+        [data]="parks"
         [label]="'Park'"
-        [placeholder]="'Search by park name'"
-        [disabled]="typeAheadDisabled"
-        [model]="modelPark"
-        (output)="parkTypeaheadOutput($event)"
+        [placeholder]="parkDisabled ? 'Select a date to see parks' : 'Search by park name'"
+        [disabled]="parkDisabled"
       ></app-typeahead>
     </div>
     <div class="col-sm-12 col-md-6 col-lg-3">
-      <app-select
-        [id]="'sub-area-select'"
-        [data]="subAreas.selectData"
-        [model]="modelSubArea"
-        [label]="'Sub-areas'"
+      <app-typeahead *ngIf="fields.subArea"
+        #subAreaTypeAhead
+        [control]="fields.subArea"
+        [id]="'subareas-typeahead'"
+        [data]="subAreas"
+        [label]="'Subarea'"
+        [placeholder]="subAreaDisabled ? 'Select a park to see subareas' : 'Search by subarea name'"
         [disabled]="subAreaDisabled"
-        (output)="subAreaOutput($event)"
-      ></app-select>
+      ></app-typeahead>
     </div>
     <div class="col-sm-12 col-md-6 col-lg-3 align-self-end">
       <button
@@ -51,3 +53,9 @@
     </div>
   </div>
 </div>
+
+<ng-template #historicalPill let-r="result" let-t="term">
+  <ngb-highlight [result]="r.display" [term]="t"></ngb-highlight>
+  <div class="mx-2 badge bg-primary historical-pill">historical</div>
+</ng-template>
+

--- a/src/app/enter-data/sub-area-search/sub-area-search.component.scss
+++ b/src/app/enter-data/sub-area-search/sub-area-search.component.scss
@@ -18,3 +18,7 @@
         max-width: 40%;
     }
 }
+
+.historical-pill {
+    background-color: #2464A4 !important;
+}

--- a/src/app/services/park.service.spec.ts
+++ b/src/app/services/park.service.spec.ts
@@ -24,9 +24,11 @@ describe('ParkService', () => {
     }
   }
 
-  let mockApiServiceNoData = {
+  let mockApiServiceThrowError = {
     get: () => {
-      return of(null)
+      return () => {
+        throw new Error('error');
+      }
     }
   }
 
@@ -70,7 +72,7 @@ describe('ParkService', () => {
   });
 
   it('it throws an error inside the fetch function', async () => {
-    TestBed.overrideProvider(ApiService, { useValue: mockApiServiceNoData });
+    TestBed.overrideProvider(ApiService, { useValue: mockApiServiceThrowError });
     service = TestBed.inject(ParkService);
     loadingServiceSpy = spyOn(service['loadingService'], 'addToFetchList');
     let loggerServiceSpy = spyOn(service['loggerService'], 'error');

--- a/src/app/services/park.service.ts
+++ b/src/app/services/park.service.ts
@@ -30,16 +30,10 @@ export class ParkService {
     try {
       // we're getting a single item
       errorSubject = 'park';
-
-      // TODO: Enable this when our endpoint is ready
       this.loggerService.debug(`Park GET`);
       res = await firstValueFrom(this.apiService.get('park'));
-      let dataObj = this.utils.convertArrayIntoObjForTypeAhead(
-        res,
-        'parkName',
-        'parkName'
-      );
-      this.dataService.setItemValue(Constants.dataIds.ENTER_DATA_PARK, dataObj);
+      // We shouldn't be converting to typeahead here.
+      this.dataService.setItemValue(Constants.dataIds.ENTER_DATA_PARK, res);
     } catch (e) {
       this.loggerService.error(`${e}`);
       this.toastService.addMessage(

--- a/src/app/shared/components/typeahead/typeahead.component.html
+++ b/src/app/shared/components/typeahead/typeahead.component.html
@@ -1,14 +1,26 @@
 <label for="{{ id }}" class="fw-bold">{{ label }}</label>
-<input
+<div class="input-group">
+  <input
   id="{{ id }}"
   type="text"
-  class="form-control"
+  class="form-control border-end-0"
   placeholder="{{ placeholder }}"
   [(ngModel)]="model"
   [ngbTypeahead]="search"
+  [inputFormatter]="formatter"
   (focus)="focus$.next($any($event).target.value)"
   (click)="click$.next($any($event).target.value)"
-  (selectItem)="emit($event)"
+  (selectItem)="setControlValue($event)"
   #instance="ngbTypeahead"
   [disabled]="disabled ? true : false"
-/>
+  [resultTemplate]="rt"
+  />
+  <span class="input-group-text border-start-0 clear-button" [ngStyle]="{'background-color': disabled ? '#e9ecef' : 'white'}" (click)="setControlValue(null)" type="button">
+      <i class="bi bi-x-lg"></i>
+  </span>
+</div>
+
+<ng-template #rt let-r="result" let-t="term">
+  <ngb-highlight *ngIf="!r.template" [result]="r.display" [term]="t"></ngb-highlight>
+  <ng-container *ngIf="r.template" [ngTemplateOutlet]="r.template" [ngTemplateOutletContext]="{result:r,term:t}"></ng-container>
+</ng-template>

--- a/src/app/shared/components/typeahead/typeahead.component.scss
+++ b/src/app/shared/components/typeahead/typeahead.component.scss
@@ -1,0 +1,14 @@
+.dropdown-menu { 
+  width: 100%;
+  max-width: 100%;
+}
+
+.clear-button {
+  color: #ced4da;
+  background-color: white;
+  border-left: none;
+  cursor: pointer;
+  &:hover {
+    color: #494949;
+  }
+}

--- a/src/app/shared/utils/utils.spec.ts
+++ b/src/app/shared/utils/utils.spec.ts
@@ -3,8 +3,8 @@ import { Utils } from './utils';
 describe('Utils Testing', async () => {
   it('Should convert JS Date to NGBDate', async () => {
     let utils = new Utils();
-    let typeAheadObj = utils.convertArrayIntoObjForTypeAhead([{'key':'value'}], 'key', 'typeahead');
-    expect(typeAheadObj.typeAheadData.length).toEqual(1);
+    let typeAheadObj = utils.convertArrayIntoObjForTypeAhead([{'key':'value'}], 'key');
+    expect(typeAheadObj.length).toEqual(1);
     let selectObj = utils.convertArrayIntoObjForSelect([{'key':{'selectId': 'someId', 'selectLabel': 'someLabel'}}], 'key', 'selectId', 'selectLabel');
     expect(selectObj.selectData.length).toEqual(1);
 

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -4,14 +4,16 @@ import { Constants } from './constants';
 export class Utils {
   public convertArrayIntoObjForTypeAhead(
     array,
-    valueToUseAsKey,
     valueToUseForTypeAhead
   ) {
-    let obj = { typeAheadData: [] as any[] };
+    let obj: any[] = [];
     for (let i = 0; i < array.length; i++) {
       const element = array[i];
-      obj[element[valueToUseAsKey]] = element;
-      obj.typeAheadData.push(element[valueToUseForTypeAhead]);
+      obj.push({
+        display: element[valueToUseForTypeAhead],
+        value: element,
+        template: null // Stubbed for custom typeahead template
+      });
     }
     return obj;
   }


### PR DESCRIPTION
### Jira Ticket:
BRS-972

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-972

### Description:
This ticket is part I of updating the A&R UI to handle historical reports - the `enter-data` search has been modified to display `historical` pills next to legacy parks/subareas.

Some QOL (NOBUG) improvements made while in this area of code: now both the park and subarea fields support typeahead predictions. Also, these field changes come with an ability to clear the field on a button press rather than focusing on the field, selecting and then deleting the text.

The `ngbTypeahead` package has a few limitations: for example, the `historical` pill can only be shown in the dropdown, and not in the field when an item is selected. 