### PR TITLE
BRS-972-2 FE changes to display legacy data

### DIFF
--- a/src/app/enter-data/accordion-manager/accordion-manager.component.html
+++ b/src/app/enter-data/accordion-manager/accordion-manager.component.html
@@ -21,3 +21,5 @@
     <app-boating-accordion (click)="accordionToggle('collapseboating')"></app-boating-accordion>
   </div>
 </div>
+
+<app-centered-text-block *ngIf="noAccordions()" [text]="'No data available for this subarea on this month.'"></app-centered-text-block>

--- a/src/app/enter-data/accordion-manager/accordion-manager.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/accordion-manager.component.spec.ts
@@ -27,7 +27,7 @@ describe('AccordionManagerComponent', () => {
     ]
   };
   const mockDataService = {
-    getItemValue: (item) => {
+    watchItem: (item) => {
       return of(subarea)
     }
   }

--- a/src/app/enter-data/accordion-manager/accordion-manager.module.ts
+++ b/src/app/enter-data/accordion-manager/accordion-manager.module.ts
@@ -9,6 +9,7 @@ import { BackcountryCampingAccordionComponent } from './backcountry-camping-acco
 import { GroupCampingAccordionComponent } from './group-camping-accordion/group-camping-accordion.component';
 import { BoatingAccordionComponent } from './boating-accordion/boating-accordion.component';
 import { BackcountryCabinsAccordionComponent } from './backcountry-cabins-accordion/backcountry-cabins-accordion.component';
+import { CenteredTextBlockModule } from 'src/app/shared/components/centered-text-block/centered-text-block.module';
 
 @NgModule({
   declarations: [
@@ -21,7 +22,7 @@ import { BackcountryCabinsAccordionComponent } from './backcountry-cabins-accord
     BoatingAccordionComponent,
     BackcountryCabinsAccordionComponent,
   ],
-  imports: [CommonModule, AccordionModule],
+  imports: [CommonModule, AccordionModule, CenteredTextBlockModule],
   exports: [AccordionManagerComponent],
 })
 export class AccordionManagerModule {}

--- a/src/app/enter-data/accordion-manager/backcountry-cabins-accordion/backcountry-cabins-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/backcountry-cabins-accordion/backcountry-cabins-accordion.component.html
@@ -3,9 +3,10 @@
   [icon]="icons.backcountryCabins"
   [id]="'backcountryCabins'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'backcountry-cabins'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/backcountry-cabins-accordion/backcountry-cabins-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/backcountry-cabins-accordion/backcountry-cabins-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BackcountryCabinsAccordionComponent } from './backcountry-cabins-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('BackcountryCabinsAccordionComponent', () => {
   let component: BackcountryCabinsAccordionComponent;
@@ -20,5 +21,24 @@ describe('BackcountryCabinsAccordionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // TODO: build this out to check more than just the length of the summaries array
+  it('builds accordion', async () => {
+    component.data = MockData.mockBackcountryCabinRecord_1;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(2);
+  });
+
+  it('builds legacy accordion', async () => {
+    component.data = MockData.mockBackcountryCabinRecord_Legacy;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(2);
+  });
+
+  it('unsubscribes on destroy', async () => {
+    const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(subSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.html
@@ -3,9 +3,10 @@
   [icon]="icons.backcountryCamping"
   [id]="'backcountryCamping'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'backcountry-camping'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BackcountryCampingAccordionComponent } from './backcountry-camping-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('BackcountryCampingAccordionComponent', () => {
   let component: BackcountryCampingAccordionComponent;
@@ -21,4 +22,23 @@ describe('BackcountryCampingAccordionComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+    // TODO: build this out to check more than just the length of the summaries array
+    it('builds accordion', async () => {
+      component.data = MockData.mockBackcountryCampingRecord_1;
+      component.buildAccordion();
+      expect(component.summaries.length).toEqual(1);
+    });
+  
+    it('builds legacy accordion', async () => {
+      component.data = MockData.mockBackcountryCampingRecord_Legacy;
+      component.buildAccordion();
+      expect(component.summaries.length).toEqual(1);
+    });
+  
+    it('unsubscribes on destroy', async () => {
+      const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+      component.ngOnDestroy();
+      expect(subSpy).toHaveBeenCalled();
+    });
 });

--- a/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.ts
@@ -23,7 +23,7 @@ export class BackcountryCampingAccordionComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
+        .watchItem(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
         .subscribe((res) => {
           this.data = res;
           this.buildAccordion();
@@ -32,26 +32,38 @@ export class BackcountryCampingAccordionComponent implements OnDestroy {
   }
 
   buildAccordion() {
-    this.summaries = [
-      {
+    // legacy data is vastly different
+    if (this.data?.isLegacy) {
+      this.summaries = [{
         attendanceItems: [
           {
             itemName: 'People',
             value: this.data?.people,
-          },
-        ],
-        revenueLabel: 'Net revenue',
-        revenueItems: [
-          {
-            itemName: 'Gross camping revenue',
-            value: this.data?.grossCampingRevenue,
-          },
-        ],
-        revenueTotal: this.formulaService.basicNetRevenue([
-          this.data?.grossCampingRevenue,
-        ]),
-      },
-    ];
+          }
+        ]
+      }]
+    } else {
+      this.summaries = [
+        {
+          attendanceItems: [
+            {
+              itemName: 'People',
+              value: this.data?.people,
+            },
+          ],
+          revenueLabel: 'Net revenue',
+          revenueItems: [
+            {
+              itemName: 'Gross camping revenue',
+              value: this.data?.grossCampingRevenue,
+            },
+          ],
+          revenueTotal: this.formulaService.basicNetRevenue([
+            this.data?.grossCampingRevenue,
+          ]),
+        },
+      ];
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.html
@@ -3,9 +3,10 @@
   [icon]="icons.boating"
   [id]="'boating'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'boating'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BoatingAccordionComponent } from './boating-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('BoatingAccordionComponent', () => {
   let component: BoatingAccordionComponent;
@@ -21,4 +22,24 @@ describe('BoatingAccordionComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // TODO: build this out to check more than just the length of the summaries array
+  it('builds accordion', async () => {
+    component.data = MockData.mockBoatingRecord_1;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(1);
+  });
+
+  it('builds legacy accordion', async () => {
+    component.data = MockData.mockBoatingRecord_Legacy;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(1);
+  });
+
+  it('unsubscribes on destroy', async () => {
+    const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(subSpy).toHaveBeenCalled();
+  });
+
 });

--- a/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/boating-accordion/boating-accordion.component.ts
@@ -23,7 +23,7 @@ export class BoatingAccordionComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ACCORDION_BOATING)
+        .watchItem(Constants.dataIds.ACCORDION_BOATING)
         .subscribe((res) => {
           this.data = res;
           this.buildAccordion();
@@ -49,14 +49,16 @@ export class BoatingAccordionComponent implements OnDestroy {
             value: this.data?.boatAttendanceMiscellaneous,
           },
         ],
-        attendanceTotal: this.formulaService.boatingAttendance(
-          [
-            this.data?.boatAttendanceNightsOnDock,
-            this.data?.boatAttendanceNightsOnBouys,
-            this.data?.boatAttendanceMiscellaneous,
-          ],
-          this.data?.config?.attendanceModifier
-        ),
+        attendanceTotal: this.data?.isLegacy ?
+          this.formulaService.formatLegacyAttendance(this.data?.legacyData?.legacy_boatingTotalAttendancePeople) :
+          this.formulaService.boatingAttendance(
+            [
+              this.data?.boatAttendanceNightsOnDock,
+              this.data?.boatAttendanceNightsOnBouys,
+              this.data?.boatAttendanceMiscellaneous,
+            ],
+            this.data?.config?.attendanceModifier
+          ),
         revenueLabel: 'Net revenue',
         revenueItems: [
           {
@@ -64,9 +66,11 @@ export class BoatingAccordionComponent implements OnDestroy {
             value: this.data?.boatRevenueGross,
           },
         ],
-        revenueTotal: this.formulaService.basicNetRevenue([
-          this.data?.boatRevenueGross,
-        ]),
+        revenueTotal: this.data?.isLegacy ?
+          this.formulaService.formatLegacyRevenue(this.data?.legacyData?.legacy_boatingTotalNetRevenue) :
+          this.formulaService.basicNetRevenue([
+            this.data?.boatRevenueGross,
+          ]),
       },
     ];
   }

--- a/src/app/enter-data/accordion-manager/day-use-accordion/day-use-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/day-use-accordion/day-use-accordion.component.html
@@ -3,9 +3,13 @@
   [icon]="icons.dayUse"
   [id]="'dayuse'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'day-use'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-summaries [summaries]="newSummaries"></app-accordion-summaries>
+<app-accordion-notes *ngIf="data?.isLegacy" [notes]="legacyNotes" [label]="'Picnic variance notes'"></app-accordion-notes>
+<app-accordion-summaries *ngIf="data?.isLegacy" [summaries]="miscSummaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/day-use-accordion/day-use-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/day-use-accordion/day-use-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DayUseAccordionComponent } from './day-use-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('DayUseAccordionComponent', () => {
   let component: DayUseAccordionComponent;
@@ -20,5 +21,24 @@ describe('DayUseAccordionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // TODO: build this out to check more than just the length of the summaries array
+  it('builds accordion', async () => {
+    component.data = MockData.mockDayUseRecord_1;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(2);
+  });
+
+  it('builds legacy accordion', async () => {
+    component.data = MockData.mockDayUseRecord_Legacy;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(2);
+  });
+
+  it('unsubscribes on destroy', async () => {
+    const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(subSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.html
@@ -3,9 +3,10 @@
   [icon]="icons.frontcountryCabins"
   [id]="'frontcountryCabins'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'frontcountry-cabins'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FrontcountryCabinsAccordionComponent } from './frontcountry-cabins-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('FrontcountryCabinsAccordionComponent', () => {
   let component: FrontcountryCabinsAccordionComponent;
@@ -20,5 +21,24 @@ describe('FrontcountryCabinsAccordionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // TODO: build this out to check more than just the length of the summaries array
+  it('builds accordion', async () => {
+    component.data = MockData.mockFrontcountryCabinsRecord_1;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(1);
+  });
+
+  it('builds legacy accordion', async () => {
+    component.data = MockData.mockFrontcountryCabinsRecord_Legacy;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(1);
+  });
+
+  it('unsubscribes on destroy', async () => {
+    const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(subSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-cabins-accordion/frontcountry-cabins-accordion.component.ts
@@ -23,7 +23,7 @@ export class FrontcountryCabinsAccordionComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
+        .watchItem(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
         .subscribe((res) => {
           this.data = res;
           this.buildAccordion();
@@ -32,31 +32,52 @@ export class FrontcountryCabinsAccordionComponent implements OnDestroy {
   }
 
   buildAccordion() {
-    this.summaries = [
-      {
-        attendanceLabel: 'Total attendance',
-        attendanceItems: [
-          {
-            itemName: 'Parties',
-            value: this.data?.totalAttendanceParties,
-          },
-        ],
-        attendanceTotal: this.formulaService.frontcountryCabinsAttendance(
-          [this.data?.totalAttendanceParties],
-          this.data?.config?.attendanceModifier
-        ),
-        revenueLabel: 'Net revenue',
-        revenueItems: [
-          {
-            itemName: 'Gross camping revenue',
-            value: this.data?.revenueGrossCamping,
-          },
-        ],
-        revenueTotal: this.formulaService.basicNetRevenue([
-          this.data?.revenueGrossCamping,
-        ]),
-      },
-    ];
+    if (this.data?.isLegacy) {
+      this.summaries = [
+        {
+          isLegacy: true,
+          attendanceItems: [
+            {
+              itemName: 'Parties',
+              value: this.data?.totalAttendanceParties,
+            },
+          ],
+          revenueItems: [
+            {
+              itemName: 'Gross camping revenue',
+              value: this.data?.revenueGrossCamping,
+            },
+          ],
+        },
+      ];
+
+    } else {
+      this.summaries = [
+        {
+          attendanceLabel: 'Total attendance',
+          attendanceItems: [
+            {
+              itemName: 'Parties',
+              value: this.data?.totalAttendanceParties,
+            },
+          ],
+          attendanceTotal: this.formulaService.frontcountryCabinsAttendance(
+            [this.data?.totalAttendanceParties],
+            this.data?.config?.attendanceModifier
+          ),
+          revenueLabel: 'Net revenue',
+          revenueItems: [
+            {
+              itemName: 'Gross camping revenue',
+              value: this.data?.revenueGrossCamping,
+            },
+          ],
+          revenueTotal: this.formulaService.basicNetRevenue([
+            this.data?.revenueGrossCamping,
+          ]),
+        },
+      ];
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.html
@@ -3,9 +3,10 @@
   [icon]="icons.frontcountryCamping"
   [id]="'frontcountryCamping'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'frontcountry-camping'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FrontcountryCampingAccordionComponent } from './frontcountry-camping-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('FrontcountryCampingAccordionComponent', () => {
   let component: FrontcountryCampingAccordionComponent;
@@ -20,5 +21,24 @@ describe('FrontcountryCampingAccordionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // TODO: build this out to check more than just the length of the summaries array
+  it('builds accordion', async () => {
+    component.data = MockData.mockFrontcountryCampingRecord_1;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(3);
+  });
+
+  it('builds legacy accordion', async () => {
+    component.data = MockData.mockFrontcountryCampingRecord_Legacy;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(5);
+  });
+
+  it('unsubscribes on destroy', async () => {
+    const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(subSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.html
+++ b/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.html
@@ -3,9 +3,10 @@
   [icon]="icons.groupCamping"
   [id]="'groupCamping'"
   [secondaryText]="'Last updated: ' + data?.lastUpdatedAccordion"
-  [notes]="data?.notes"
-  [summaries]="summaries"
   [editLink]="'group-camping'"
   [recordLock]="data?.isLocked"
+  [isLegacy]="data?.isLegacy"
 >
+<app-accordion-summaries [summaries]="summaries"></app-accordion-summaries>
+<app-accordion-notes [notes]="data?.notes"></app-accordion-notes>
 </app-accordion>

--- a/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GroupCampingAccordionComponent } from './group-camping-accordion.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('GroupCampingAccordionComponent', () => {
   let component: GroupCampingAccordionComponent;
@@ -20,5 +21,24 @@ describe('GroupCampingAccordionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+  
+  // TODO: build this out to check more than just the length of the summaries array
+  it('builds accordion', async () => {
+    component.data = MockData.mockGroupCampingRecord_1;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(2);
+  });
+
+  it('builds legacy accordion', async () => {
+    component.data = MockData.mockGroupCampingRecord_Legacy;
+    component.buildAccordion();
+    expect(component.summaries.length).toEqual(2);
+  });
+
+  it('unsubscribes on destroy', async () => {
+    const subSpy = spyOn<any>(component['subscriptions'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(subSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/group-camping-accordion/group-camping-accordion.component.ts
@@ -23,7 +23,7 @@ export class GroupCampingAccordionComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ACCORDION_GROUP_CAMPING)
+        .watchItem(Constants.dataIds.ACCORDION_GROUP_CAMPING)
         .subscribe((res) => {
           this.data = res;
           this.buildAccordion();
@@ -32,69 +32,122 @@ export class GroupCampingAccordionComponent implements OnDestroy {
   }
 
   buildAccordion() {
-    this.summaries = [
-      {
-        title: 'Standard rate groups',
-        attendanceLabel: 'Total People',
-        attendanceItems: [
-          {
-            itemName: 'Standard group nights',
-            value: this.data?.standardRateGroupsTotalPeopleStandard,
-          },
-          {
-            itemName: 'Adults (16+)',
-            value: this.data?.standardRateGroupsTotalPeopleAdults,
-          },
-          {
-            itemName: 'Youths (6-15)',
-            value: this.data?.standardRateGroupsTotalPeopleYouth,
-          },
-          {
-            itemName: 'Kids (0-5)',
-            value: this.data?.standardRateGroupsTotalPeopleKids,
-          },
-        ],
-        attendanceTotal: this.formulaService.groupCampingStandardAttendance([
-          this.data?.standardRateGroupsTotalPeopleAdults,
-          this.data?.standardRateGroupsTotalPeopleYouth,
-          this.data?.standardRateGroupsTotalPeopleKids,
-        ]),
-        revenueLabel: 'Net revenue',
-        revenueItems: [
-          {
-            itemName: 'Gross standard group revenue',
-            value: this.data?.standardRateGroupsRevenueGross,
-          },
-        ],
-        revenueTotal: this.formulaService.basicNetRevenue([
-          this.data?.standardRateGroupsRevenueGross,
-        ]),
-      },
-      {
-        title: 'Youth rate groups',
-        attendanceLabel: 'Total attendance',
-        attendanceItems: [
-          {
-            itemName: 'Youth group nights',
-            value: this.data?.youthRateGroupsAttendanceGroupNights,
-          },
-          {
-            itemName: 'People',
-            value: this.data?.youthRateGroupsAttendancePeople,
-          },
-        ],
-        revenueLabel: 'Net revenue',
-        revenueItems: [
-          {
-            itemName: 'Gross youth group revenue',
-            value: this.data?.youthRateGroupsRevenueGross,
-          },
-        ],
-        revenueTotal: this.formulaService.basicNetRevenue([
-          this.data?.youthRateGroupsRevenueGross,
-        ]),
-      },
-    ];
+    // legacy and non-legacy layouts are vastly different
+    if (this.data?.isLegacy) {
+      this.summaries = [
+        {
+          isLegacy: true,
+          title: 'Standard rate groups',
+          attendanceItems: [
+            {
+              itemName: 'Standard group nights',
+              value: this.data?.standardRateGroupsTotalPeopleStandard,
+            },
+            {
+              itemName: 'Adults (16+)',
+              value: this.data?.standardRateGroupsTotalPeopleAdults,
+            },
+            {
+              itemName: 'Youths (6-15)',
+              value: this.data?.standardRateGroupsTotalPeopleYouth,
+            },
+            {
+              itemName: 'Kids (0-5)',
+              value: this.data?.standardRateGroupsTotalPeopleKids,
+            },
+          ],
+        },
+        {
+          isLegacy: true,
+          title: 'Youth rate groups',
+          attendanceLabel: 'Total people',
+          attendanceItems: [
+            {
+              itemName: 'Group nights',
+              value: this.data?.youthRateGroupsAttendanceGroupNights,
+            },
+            {
+              itemName: 'People',
+              value: this.data?.youthRateGroupsAttendancePeople,
+            },
+          ],
+          revenueLabel: 'Net revenue',
+          revenueItems: [
+            {
+              itemName: 'Gross standard group revenue',
+              value: this.data?.legacyData?.legacy_groupCampingTotalGrossRevenue
+            },
+          ],
+          revenueTotal: this.formulaService.formatLegacyRevenue(this.data?.legacyData?.legacy_groupCampingTotalNetRevenue),
+        }
+      ];
+    } else {
+      this.summaries = [
+        {
+          title: 'Standard rate groups',
+          attendanceLabel: 'Total People',
+          attendanceItems: [
+            {
+              itemName: 'Standard group nights',
+              value: this.data?.standardRateGroupsTotalPeopleStandard,
+            },
+            {
+              itemName: 'Adults (16+)',
+              value: this.data?.standardRateGroupsTotalPeopleAdults,
+            },
+            {
+              itemName: 'Youths (6-15)',
+              value: this.data?.standardRateGroupsTotalPeopleYouth,
+            },
+            {
+              itemName: 'Kids (0-5)',
+              value: this.data?.standardRateGroupsTotalPeopleKids,
+            },
+          ],
+          attendanceTotal: this.formulaService.groupCampingStandardAttendance([
+            this.data?.standardRateGroupsTotalPeopleAdults,
+            this.data?.standardRateGroupsTotalPeopleYouth,
+            this.data?.standardRateGroupsTotalPeopleKids,
+          ]),
+          revenueLabel: 'Net revenue',
+          revenueItems: [
+            {
+              itemName: 'Gross standard group revenue',
+              value: this.data?.isLegacy ?
+                this.data?.legacyData?.legacy_groupCampingTotalGrossRevenue :
+                this.data?.standardRateGroupsRevenueGross,
+            },
+          ],
+          revenueTotal: this.formulaService.basicNetRevenue([
+            this.data?.standardRateGroupsRevenueGross,
+          ]),
+        },
+        {
+          title: 'Youth rate groups',
+          attendanceLabel: 'Total attendance',
+          attendanceItems: [
+            {
+              itemName: 'Youth group nights',
+              value: this.data?.youthRateGroupsAttendanceGroupNights,
+            },
+            {
+              itemName: 'People',
+              value: this.data?.youthRateGroupsAttendancePeople,
+            },
+          ],
+          revenueLabel: 'Net revenue',
+          revenueItems: [
+            {
+              itemName: 'Gross youth group revenue',
+              value: this.data?.youthRateGroupsRevenueGross,
+            },
+          ],
+          revenueTotal: this.formulaService.basicNetRevenue([
+            this.data?.youthRateGroupsRevenueGross,
+          ]),
+        }
+      ];
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/enter-data/enter-data.component.ts
+++ b/src/app/enter-data/enter-data.component.ts
@@ -32,7 +32,7 @@ export class EnterDataComponent implements OnDestroy {
   constructor(protected dataService: DataService, protected router: Router) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_SUB_AREA)
+        .watchItem(Constants.dataIds.ENTER_DATA_SUB_AREA)
         .subscribe((res) => {
           this.subAreaData = res;
         })
@@ -49,7 +49,7 @@ export class EnterDataComponent implements OnDestroy {
 
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
+        .watchItem(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .subscribe((res) => {
           if (res) {
             this.formParams = res;

--- a/src/app/enter-data/sub-area-search/sub-area-search.component.spec.ts
+++ b/src/app/enter-data/sub-area-search/sub-area-search.component.spec.ts
@@ -9,12 +9,15 @@ import { FormService } from 'src/app/services/form.service';
 import { SubAreaService } from 'src/app/services/sub-area.service';
 
 import { SubAreaSearchComponent } from './sub-area-search.component';
+import { Utils } from 'src/app/shared/utils/utils';
+import { MockData } from 'src/app/shared/utils/mock.data';
 
 describe('SubAreaSearchComponent', () => {
   let component: SubAreaSearchComponent;
   let fixture: ComponentFixture<SubAreaSearchComponent>;
   let router;
   let subAreaService;
+  let utils = new Utils();
 
   const routeValue = {
     snapshot: { queryParams: { id: 123 } }
@@ -44,7 +47,7 @@ describe('SubAreaSearchComponent', () => {
   ];
 
   const mockDataService = {
-    getItemValue: (item) => {
+    watchItem: (item) => {
       return of(
         typeaheadData
       )
@@ -245,22 +248,31 @@ describe('SubAreaSearchComponent', () => {
 
     expect(serviceSpy).toHaveBeenCalled();
 
-    await component.setFormState('none');
+    component.parks = utils.convertArrayIntoObjForTypeAhead([MockData.mockPark_1, MockData.mockPark_2, MockData.mockLegacyPark], 'parkName');
+    component.formatLegacyTypeaheadLabel(component.parks);
+
+    component.modelDate = null;
+    component.fields.park.setValue(null)
+    component.fields.subArea.setValue(null)
+    component.updateFormState();
     expect(component.parkDisabled).toBe(true);
     expect(component.subAreaDisabled).toBe(true);
     expect(component.continueDisabled).toBe(true);
 
-    await component.setFormState('date');
+    component.modelDate = '202201';
+    component.updateFormState();
     expect(component.parkDisabled).toBe(false);
     expect(component.subAreaDisabled).toBe(true);
     expect(component.continueDisabled).toBe(true);
 
-    await component.setFormState('park');
+    component.fields.park.setValue({value: MockData.mockPark_1})
+    await component.updateFormState();
     expect(component.parkDisabled).toBe(false);
     expect(component.subAreaDisabled).toBe(false);
     expect(component.continueDisabled).toBe(true);
 
-    await component.setFormState('subArea');
+    component.fields.subArea.setValue({value: MockData.mockSubArea_1})
+    await component.updateFormState();
     expect(component.parkDisabled).toBe(false);
     expect(component.subAreaDisabled).toBe(false);
     expect(component.continueDisabled).toBe(false);

--- a/src/app/export-reports/export-reports.component.spec.ts
+++ b/src/app/export-reports/export-reports.component.spec.ts
@@ -12,7 +12,7 @@ describe('ExportReportsComponent', () => {
   let fixture: ComponentFixture<ExportReportsComponent>;
 
   const mockDataService = {
-    getItemValue: (item) => {
+    watchItem: (item) => {
       return of({
         jobObj: {
           id: '123',

--- a/src/app/export-reports/export-reports.component.ts
+++ b/src/app/export-reports/export-reports.component.ts
@@ -43,7 +43,7 @@ export class ExportReportsComponent implements OnInit, OnDestroy {
   ) {
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.EXPORT_ALL_POLLING_DATA)
+        .watchItem(Constants.dataIds.EXPORT_ALL_POLLING_DATA)
         .subscribe((res) => {
           if (res) {
             this.initialLoad = false;

--- a/src/app/forms/backcountry-cabins/backcountry-cabins.component.ts
+++ b/src/app/forms/backcountry-cabins/backcountry-cabins.component.ts
@@ -47,7 +47,7 @@ export class BackcountryCabinsComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CABINS)
+        .watchItem(Constants.dataIds.ACCORDION_BACKCOUNTRY_CABINS)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/backcountry-camping/backcountry-camping.component.ts
+++ b/src/app/forms/backcountry-camping/backcountry-camping.component.ts
@@ -50,7 +50,7 @@ export class BackcountryCampingComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
+        .watchItem(Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/boating/boating.component.ts
+++ b/src/app/forms/boating/boating.component.ts
@@ -50,7 +50,7 @@ export class BoatingComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_BOATING)
+        .watchItem(Constants.dataIds.ACCORDION_BOATING)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/cancel-button/cancel-button.component.spec.ts
+++ b/src/app/forms/cancel-button/cancel-button.component.spec.ts
@@ -32,7 +32,7 @@ describe('CancelButtonComponent', () => {
   ];
 
   const mockDataService = {
-    getItemValue: (item) => {
+    watchItem: (item) => {
       return of({
         date: new Date(),
         parkName: 'Park Name',

--- a/src/app/forms/cancel-button/cancel-button.component.ts
+++ b/src/app/forms/cancel-button/cancel-button.component.ts
@@ -25,7 +25,7 @@ export class CancelButtonComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
+        .watchItem(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .subscribe((res) => {
           if (res) {
             this.navParams['date'] = res.date;

--- a/src/app/forms/day-use/day-use.component.ts
+++ b/src/app/forms/day-use/day-use.component.ts
@@ -51,7 +51,7 @@ export class DayUseComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_DAY_USE)
+        .watchItem(Constants.dataIds.ACCORDION_DAY_USE)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/frontcountry-cabins/frontcountry-cabins.component.ts
+++ b/src/app/forms/frontcountry-cabins/frontcountry-cabins.component.ts
@@ -46,7 +46,7 @@ export class FrontcountryCabinsComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
+        .watchItem(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/frontcountry-camping/frontcountry-camping.component.ts
+++ b/src/app/forms/frontcountry-camping/frontcountry-camping.component.ts
@@ -53,7 +53,7 @@ export class FrontcountryCampingComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CAMPING)
+        .watchItem(Constants.dataIds.ACCORDION_FRONTCOUNTRY_CAMPING)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/group-camping/group-camping.component.ts
+++ b/src/app/forms/group-camping/group-camping.component.ts
@@ -52,7 +52,7 @@ export class GroupCampingComponent extends BaseFormComponent {
     // push existing form data to parent subscriptions
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ACCORDION_GROUP_CAMPING)
+        .watchItem(Constants.dataIds.ACCORDION_GROUP_CAMPING)
         .subscribe((res) => {
           if (res) {
             this.data = res;

--- a/src/app/forms/park-header/park-header.component.spec.ts
+++ b/src/app/forms/park-header/park-header.component.spec.ts
@@ -9,7 +9,7 @@ describe('ParkHeaderComponent', () => {
   let fixture: ComponentFixture<ParkHeaderComponent>;
   let dataService;
   const mockDataService = {
-    getItemValue: (item) => {
+    watchItem: (item) => {
       return of({
         date: new Date(),
         parkName: 'Park Name',
@@ -19,7 +19,7 @@ describe('ParkHeaderComponent', () => {
     }
   }
   const mockDataServiceNoDate = {
-    getItemValue: (item) => {
+    watchItem: (item) => {
       return of({
         parkName: 'Park Name',
         subAreaId: 'SubArea Id',

--- a/src/app/forms/park-header/park-header.component.ts
+++ b/src/app/forms/park-header/park-header.component.ts
@@ -20,7 +20,7 @@ export class ParkHeaderComponent implements OnDestroy {
   constructor(protected dataService: DataService) {
     this.subscriptions.add(
       this.dataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
+        .watchItem(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .subscribe((res) => {
           if (res) {
             this.parkName = res.parkName;

--- a/src/app/lock-records/fiscal-year-lock-table/fiscal-year-lock-table.component.spec.ts
+++ b/src/app/lock-records/fiscal-year-lock-table/fiscal-year-lock-table.component.spec.ts
@@ -9,7 +9,7 @@ describe('FiscalYearLockTableComponent', () => {
   let dataService: DataService;
 
   const mockDataService = {
-    getItemValue: () => {
+    watchItem: () => {
       return of([
         {
             isLocked: true

--- a/src/app/lock-records/fiscal-year-lock-table/fiscal-year-lock-table.component.ts
+++ b/src/app/lock-records/fiscal-year-lock-table/fiscal-year-lock-table.component.ts
@@ -20,7 +20,7 @@ export class FiscalYearLockTableComponent implements OnInit {
   constructor(protected dataService: DataService) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.LOCK_RECORDS_FISCAL_YEARS_DATA)
+        .watchItem(Constants.dataIds.LOCK_RECORDS_FISCAL_YEARS_DATA)
         .subscribe((res) => {
           if (res && res.length) {
             this.tableRows = this.filterLockedYears(res);

--- a/src/app/lock-records/lock-records.component.ts
+++ b/src/app/lock-records/lock-records.component.ts
@@ -29,7 +29,7 @@ export class LockRecordsComponent implements OnInit {
   ) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.LOCK_RECORDS_FISCAL_YEARS_DATA)
+        .watchItem(Constants.dataIds.LOCK_RECORDS_FISCAL_YEARS_DATA)
         .subscribe((res) => {
           this.fiscalYearsList = res;
         })

--- a/src/app/services/activity.service.ts
+++ b/src/app/services/activity.service.ts
@@ -49,6 +49,23 @@ export class ActivityService {
         })
       );
 
+      // If a record exists but the config doesn't contain that activity (ie, the activity was removed or is legacy)
+      // then we still need the accordion for that activity to show up to hold the record data.
+      // If a record does not exist, res will not contain a pk.
+      if (res?.pk) {
+        // We have to add the activity to the accordion list
+        const accordionListId = Constants.dataIds.ACCORDION_ALL_AVAILABLE_RECORDS_LIST
+        let activityList = this.dataService.getItemValue(accordionListId);
+        if (!activityList) {
+          this.dataService.setItemValue(accordionListId, [activity]);
+        } else {
+          if (!activityList.includes(activity)) {
+            activityList.push(activity);
+            this.dataService.setItemValue(accordionListId, activityList);
+          }
+        }
+      }
+
       // Date for accordion
       res.lastUpdatedAccordion = res.lastUpdated
         ? moment(new Date(res.lastUpdated)).format('YYYY-MM-DD')

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -20,9 +20,15 @@ export class DataService {
     this.data[id].next(value);
   }
 
+  // For observables - watch for changes in dataid
+  public watchItem(id) {
+    this.checkIfDataExists(id) ? null : this.initItem(id);
+    return this.data[id];
+  }
+  // For getting the current value of dataid
   public getItemValue(id) {
     this.checkIfDataExists(id) ? null : this.initItem(id);
-    return this.data[id].asObservable();
+    return this.data[id].value;
   }
 
   clearItemValue(id): void {

--- a/src/app/services/formula.service.ts
+++ b/src/app/services/formula.service.ts
@@ -307,4 +307,28 @@ export class FormulaService {
       formula: formula,
     };
   }
+
+  /**
+   * Formats legacy attendance values.
+   * @param value value to format
+   * @returns `formulaResult` object
+   */
+  formatLegacyAttendance(value: number): formulaResult {
+    return {
+      result: this.formatDecimal(value),
+      formula: '',
+    };
+  }
+
+  /**
+   * Formats legacy revenue values.
+   * @param value value to format
+   * @returns `formulaResult` object
+   */
+  formatLegacyRevenue(value: number): formulaResult {
+    return {
+      result: this.formatMoney(value),
+      formula: '',
+    };
+  }
 }

--- a/src/app/services/sub-area.service.spec.ts
+++ b/src/app/services/sub-area.service.spec.ts
@@ -10,6 +10,7 @@ import { ToastService } from './toast.service';
 import { LoggerService } from './logger.service';
 import { ApiService } from './api.service';
 import { ActivityService } from './activity.service';
+import { BehaviorSubject } from 'rxjs';
 
 describe('SubAreaService', () => {
   let dataServiceSpy;
@@ -54,7 +55,6 @@ describe('SubAreaService', () => {
     );
     loggerServiceDebugSpy = spyOn(subareaService['loggerService'], 'debug');
     loggerServiceErrorSpy = spyOn(subareaService['loggerService'], 'error');
-    apiServiceSpy = spyOn(subareaService['apiService'], 'get');
   });
 
   it('should be created', () => {
@@ -62,6 +62,7 @@ describe('SubAreaService', () => {
   });
 
   it('fetches subarea details', async () => {
+    apiServiceSpy = spyOn(subareaService['apiService'], 'get');
     await subareaService.fetchSubArea(2, 22, 222, null);
 
     expect(loadingServiceAddSpy).toHaveBeenCalledWith(2);
@@ -74,6 +75,15 @@ describe('SubAreaService', () => {
       subAreaId: 222,
     });
   });
+
+  it('fetches subarea activity', async () => {
+    apiServiceSpy = spyOn(subareaService['apiService'], 'get').and.returnValue(new BehaviorSubject({data:['valid_Data']}));
+    const fetchActivityDetailsSpy = spyOn(subareaService['activityService'], 'fetchActivityDetails');
+    await subareaService.fetchSubArea(2, 22, 222, 2222);
+    // Call once for every activity when searching
+    expect(fetchActivityDetailsSpy).toHaveBeenCalledTimes(Constants.ActivityTypes.length);
+  });
+
 
   it('clears accordion cache', async () => {
     subareaService.clearAccordionCache();

--- a/src/app/services/sub-area.service.ts
+++ b/src/app/services/sub-area.service.ts
@@ -22,7 +22,7 @@ export class SubAreaService {
     private loggerService: LoggerService,
     private loadingService: LoadingService,
     private activityService: ActivityService
-  ) {}
+  ) { }
 
   async fetchSubArea(id, orcs, subAreaId, date) {
     this.loadingService.addToFetchList(id);
@@ -34,13 +34,18 @@ export class SubAreaService {
       res = await firstValueFrom(
         this.apiService.get('park', { orcs: orcs, subAreaId: subAreaId })
       );
-      res = res.data[0];
+      res = res.data[0] || null;
       this.dataService.setItemValue(id, res);
 
       // If we are given a date, we want to get activity details
-      if (date && res.activities.length > 0) {
-        for (let i = 0; i < res.activities.length; i++) {
-          const activity = res.activities[i];
+      if (date) {
+        // Now that we have historical records in the system,
+        // We can't assume that a subarea only has records for the activities it has
+        // So we must query for all possible activities.
+        let activitiesList = Constants.ActivityTypes;
+        this.dataService.clearItemValue(Constants.dataIds.ACCORDION_ALL_AVAILABLE_RECORDS_LIST);
+        for (let i = 0; i < activitiesList.length; i++) {
+          const activity = activitiesList[i];
 
           // ID = accordion-{activity}
           // eg. 'accordion-Day use'

--- a/src/app/shared/components/accordion/accordion-notes/accordion-notes.component.html
+++ b/src/app/shared/components/accordion/accordion-notes/accordion-notes.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="notes">
+  <h3>{{ label }}</h3>
+  <div class="mb-5">{{ notes }}</div>
+</div>

--- a/src/app/shared/components/accordion/accordion-notes/accordion-notes.component.spec.ts
+++ b/src/app/shared/components/accordion/accordion-notes/accordion-notes.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccordionNotesComponent } from './accordion-notes.component';
+
+describe('AccordionNotesComponent', () => {
+  let component: AccordionNotesComponent;
+  let fixture: ComponentFixture<AccordionNotesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AccordionNotesComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AccordionNotesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(component.notes).toEqual('');
+    expect(component.label).toEqual('Variance notes');
+  });
+});

--- a/src/app/shared/components/accordion/accordion-notes/accordion-notes.component.ts
+++ b/src/app/shared/components/accordion/accordion-notes/accordion-notes.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-accordion-notes',
+  templateUrl: './accordion-notes.component.html',
+  styleUrls: ['./accordion-notes.component.scss']
+})
+export class AccordionNotesComponent {
+  @Input() notes: string = '';
+  @Input() label: string = 'Variance notes';
+}

--- a/src/app/shared/components/accordion/accordion-summaries/accordion-summaries.component.html
+++ b/src/app/shared/components/accordion/accordion-summaries/accordion-summaries.component.html
@@ -1,0 +1,5 @@
+<div *ngFor="let item of summaries">
+  <div class="mb-5 mt-3">
+    <app-summary-section [section]="item"></app-summary-section>
+  </div>
+</div>

--- a/src/app/shared/components/accordion/accordion-summaries/accordion-summaries.component.spec.ts
+++ b/src/app/shared/components/accordion/accordion-summaries/accordion-summaries.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccordionSummariesComponent } from './accordion-summaries.component';
+
+describe('AccordionSummariesComponent', () => {
+  let component: AccordionSummariesComponent;
+  let fixture: ComponentFixture<AccordionSummariesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AccordionSummariesComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AccordionSummariesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(component.summaries).toEqual([]);
+  });
+});

--- a/src/app/shared/components/accordion/accordion-summaries/accordion-summaries.component.ts
+++ b/src/app/shared/components/accordion/accordion-summaries/accordion-summaries.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { summarySection } from '../summary-section/summary-section.component';
+
+@Component({
+  selector: 'app-accordion-summaries',
+  templateUrl: './accordion-summaries.component.html',
+  styleUrls: ['./accordion-summaries.component.scss']
+})
+export class AccordionSummariesComponent {
+  @Input() summaries: summarySection[] = [];
+}

--- a/src/app/shared/components/accordion/accordion.component.html
+++ b/src/app/shared/components/accordion/accordion.component.html
@@ -40,7 +40,10 @@
               />
               <div class="h3 mb-0 pb-0">
                 {{ title }}
-              </div>
+              </div> 
+              <h3 *ngIf="isLegacy" >
+                <span class="badge ms-3 mt-3 bg-primary historical-pill">historical</span>
+              </h3>
             </div>
           </div>
           <div class="col justify-content-end mx-3 d-none d-lg-flex">
@@ -81,18 +84,7 @@
       aria-labelledby="title"
     >
       <div class="accordion-body border-top-0">
-        <div *ngIf="summaries">
-          <div *ngFor="let item of summaries">
-            <div class="mb-5 mt-3">
-              <app-summary-section [section]="item"></app-summary-section>
-            </div>
-          </div>
-        </div>
-        <div *ngIf="notes">
-          <h3>Variance notes</h3>
-          <div class="mb-5">{{ notes }}</div>
-        </div>
-      </div>
+        <ng-content></ng-content>
     </div>
   </div>
 </div>

--- a/src/app/shared/components/accordion/accordion.component.scss
+++ b/src/app/shared/components/accordion/accordion.component.scss
@@ -68,3 +68,7 @@ $border-radius: 4px;
     border-bottom-right-radius: $border-radius;
   }
 }
+
+.historical-pill {
+  background-color: #2464a4 ;
+}

--- a/src/app/shared/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/accordion/accordion.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Input,
   OnDestroy,
+  OnInit,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Utils } from '../../utils/utils';
@@ -16,7 +17,7 @@ import { summarySection } from './summary-section/summary-section.component';
   templateUrl: './accordion.component.html',
   styleUrls: ['./accordion.component.scss'],
 })
-export class AccordionComponent implements OnDestroy {
+export class AccordionComponent implements OnInit, OnDestroy {
   @Input() title: string = '';
   @Input() icon: string = '';
   @Input() id: string = '';
@@ -25,6 +26,7 @@ export class AccordionComponent implements OnDestroy {
   @Input() summaries: Array<summarySection> = [];
   @Input() editLink: string = '';
   @Input() recordLock;
+  @Input() isLegacy = false;
 
   private subscriptions = new Subscription();
   private formParams;
@@ -41,7 +43,7 @@ export class AccordionComponent implements OnDestroy {
   ) {
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
+        .watchItem(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .subscribe((res) => {
           if (res) {
             this.formParams = res;
@@ -49,6 +51,12 @@ export class AccordionComponent implements OnDestroy {
           }
         })
     );
+  }
+
+  ngOnInit() {
+    if (this.isLegacy) {
+      this.isLocked = true;
+    }
   }
 
   async setFiscalLockVar() {

--- a/src/app/shared/components/accordion/accordion.module.ts
+++ b/src/app/shared/components/accordion/accordion.module.ts
@@ -4,13 +4,17 @@ import { AccordionComponent } from './accordion.component';
 import { SummarySectionComponent } from './summary-section/summary-section.component';
 import { CalculationDisplayModule } from '../forms/calculation-display/calculation-display.module';
 import { TextAreaModule } from '../forms/text-area/text-area.module';
+import { AccordionSummariesComponent } from './accordion-summaries/accordion-summaries.component';
+import { AccordionNotesComponent } from './accordion-notes/accordion-notes.component';
 
 
 
 @NgModule({
   declarations: [
     AccordionComponent,
-    SummarySectionComponent
+    SummarySectionComponent,
+    AccordionSummariesComponent,
+    AccordionNotesComponent
   ],
   imports: [
     CommonModule,
@@ -19,7 +23,9 @@ import { TextAreaModule } from '../forms/text-area/text-area.module';
   ],
   exports: [
     AccordionComponent,
-    SummarySectionComponent
+    SummarySectionComponent,
+    AccordionNotesComponent,
+    AccordionSummariesComponent
   ]
 })
 export class AccordionModule { }

--- a/src/app/shared/components/accordion/summary-section/summary-section.component.html
+++ b/src/app/shared/components/accordion/summary-section/summary-section.component.html
@@ -13,8 +13,8 @@
       *ngIf="section?.attendanceTotal"
       [label]="section?.attendanceLabel?.toUpperCase()"
       [value]="section?.attendanceTotal?.result"
-      [subtext]="section?.attendanceTotal?.formula"
-      [colorClass]="'blue'"
+      [subtext]="section?.isLegacy ? '' : section?.attendanceTotal?.formula"
+      [colorClass]="section?.isLegacy ? 'grey' : 'blue'"
     ></app-calculation-display>
   </div>
   <div class="mb-3" *ngIf="section.revenueItems">
@@ -34,8 +34,8 @@
       *ngIf="section?.revenueTotal"
       [label]="section?.revenueLabel?.toUpperCase()"
       [value]="section?.revenueTotal?.result"
-      [subtext]="section?.revenueTotal?.formula"
-      [colorClass]="'green'"
+      [subtext]="section?.isLegacy ? '' : section?.revenueTotal?.formula"
+      [colorClass]="section?.isLegacy ? 'grey' : 'green'"
     ></app-calculation-display>
   </div>
 </div>

--- a/src/app/shared/components/accordion/summary-section/summary-section.component.ts
+++ b/src/app/shared/components/accordion/summary-section/summary-section.component.ts
@@ -11,6 +11,7 @@ export interface summaryLineItem {
 
 export interface summarySection {
   title?: string;
+  isLegacy?: boolean;
   attendanceLabel?: string;
   attendanceTotal?: formulaResult;
   attendanceItems?: Array<summaryLineItem>;

--- a/src/app/shared/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/components/breadcrumb/breadcrumb.component.ts
@@ -39,7 +39,7 @@ export class BreadcrumbComponent implements OnDestroy {
     );
     this.subscriptions.add(
       dataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
+        .watchItem(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .subscribe((res) => {
           if (res) {
             this.enterDataUrlParams = res;

--- a/src/app/shared/components/centered-text-block/centered-text-block.component.html
+++ b/src/app/shared/components/centered-text-block/centered-text-block.component.html
@@ -1,5 +1,3 @@
 <div class="bg-light main-text-area text-center mx-2">
-  Select the data and location above for the Attendance and Revenue data you
-  want to enter. If you want to view past enteries, you can do that by selecting
-  the date and location you want to view.
+  {{ text }}
 </div>

--- a/src/app/shared/components/forms/base-form/base-form.component.ts
+++ b/src/app/shared/components/forms/base-form/base-form.component.ts
@@ -51,7 +51,7 @@ export class BaseFormComponent implements AfterViewChecked, OnDestroy {
     this.form = this.bFormBuilder.group({});
     this.subscriptions.add(
       this.bDataService
-        .getItemValue(Constants.dataIds.ENTER_DATA_URL_PARAMS)
+        .watchItem(Constants.dataIds.ENTER_DATA_URL_PARAMS)
         .subscribe((res) => {
           if (res) {
             this.postObj['date'] = res.date;

--- a/src/app/shared/components/forms/calculation-display/calculation-display.component.scss
+++ b/src/app/shared/components/forms/calculation-display/calculation-display.component.scss
@@ -7,3 +7,7 @@
 .blue {
   background-color: $calc-blue;
 }
+
+.grey {
+  background-color: $calc-grey;
+}

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -9,6 +9,8 @@ export class Constants {
     ACCORDION_BOATING: 'accordion-Boating',
     ACCORDION_BACKCOUNTRY_CAMPING: 'accordion-Backcountry Camping',
     ACCORDION_BACKCOUNTRY_CABINS: 'accordion-Backcountry Cabins',
+    ACCORDION_LEGACY_DATA: 'accordion-Legacy Data',
+    ACCORDION_ALL_AVAILABLE_RECORDS_LIST: 'accordion-All Available Records List',
     ENTER_DATA_URL_PARAMS: 'enter-data-url-params',
     EXPORT_ALL_POLLING_DATA: 'export-all-polling-data',
     LOCK_RECORDS_FISCAL_YEARS_DATA: 'lock-records-fiscal-years-data',
@@ -17,6 +19,16 @@ export class Constants {
   public static readonly ApplicationRoles: any = {
     ADMIN: 'sysadmin',
   };
+
+  public static readonly ActivityTypes: any = [
+    'Frontcountry Camping',
+    'Frontcountry Cabins',
+    'Day Use',
+    'Group Camping',
+    'Boating',
+    'Backcountry Camping',
+    'Backcountry Cabins'
+  ]
 
   // March
   public static readonly FiscalYearFinalMonth: number = 3;

--- a/src/app/shared/utils/mock.data.ts
+++ b/src/app/shared/utils/mock.data.ts
@@ -1,0 +1,385 @@
+export class MockData {
+  // For testing
+  public static readonly mockPark_1 = {
+    pk: 'park',
+    sk: 'MOC1',
+    parkName: 'Mock Park 1',
+    roles: ['sysadmin', 'MOC1'],
+    orcs: 'MOC1',
+    subAreas: [
+      {
+        id: 'MOC1',
+        name: 'Mock SubArea 1',
+      },
+      {
+        id: 'MLS1',
+        name: 'Mock Legacy SubArea 1',
+        isLegacy: true
+      }
+    ]
+  }
+
+  public static readonly mockPark_2 = {
+    pk: 'park',
+    sk: 'MOC2',
+    parkName: 'Mock Park 2',
+    roles: ['sysadmin', 'MOC2'],
+    orcs: 'MOC2',
+    subAreas: [
+      {
+        id: 'MOC2',
+        name: 'Mock SubArea 2',
+      },
+    ]
+  }
+
+  public static readonly mockLegacyPark = {
+    pk: 'park',
+    sk: 'MLP1',
+    isLegacy: true,
+    parkName: 'Mock Legacy Park 1',
+    roles: ['sysadmin', 'MLP1'],
+    orcs: 'MLP1',
+    subAreas: [
+      {
+        id: 'MLS2',
+        name: 'Mock Legacy SubArea 2',
+        isLegacy: true
+      }
+    ]
+  }
+
+  public static readonly mockSubArea_1 = {
+    pk: 'park::MOC1',
+    sk: 'MOC1',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    roles: ['sysadmin', 'MOC1:MOC1'],
+    activities: ['Backcountry Cabins', 'Backcountry Camping', 'Boating', 'Day Use', 'Frontcountry Cabins', 'Frontcountry Camping', 'Group Camping'],
+    orcs: 'MOC1',
+    managementArea: 'Mock Management Area 1',
+    section: 'Mock Section 1',
+    region: 'Mock Region 1',
+    bundle: 'Mock Bundle 1',
+  }
+
+  public static readonly mockSubArea_2 = {
+    pk: 'park::MOC2',
+    sk: 'MOC2',
+    parkName: 'Mock Park 2',
+    subAreaName: 'Mock SubArea 2',
+    roles: ['sysadmin', 'MOC2:MOC2'],
+    activities: ['Backcountry Cabins', 'Backcountry Camping', 'Boating', 'Day Use', 'Frontcountry Cabins', 'Frontcountry Camping', 'Group Camping'],
+    orcs: 'MOC2',
+    managementArea: 'Mock Management Area 2',
+    section: 'Mock Section 2',
+    region: 'Mock Region 2',
+    bundle: 'Mock Bundle 2',
+  }
+
+  public static readonly mockLegacySubArea = {
+    pk: 'park::MLP1',
+    sk: 'MLS1',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    roles: ['sysadmin', 'MLP1:MLS1'],
+    activities: ['Backcountry Cabins', 'Backcountry Camping', 'Boating', 'Day Use', 'Frontcountry Cabins', 'Frontcountry Camping', 'Group Camping'],
+    orcs: 'MLP1',
+    managementArea: 'Mock Management Area 3',
+    section: 'Mock Section 3',
+    region: 'Mock Region 3',
+    bundle: 'Mock Bundle 3',
+    isLegacy: true
+  }
+
+  public static readonly mockBackcountryCabinRecord_1 = {
+    pk: 'MOC1::Backcountry Cabins',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    revenueFamily: 1.11,
+    peopleAdult: 1,
+    peopleFamily: 1,
+    peopleChild: 1,
+    notes: 'Mock notes',
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockBackcountryCabinRecord_Legacy = {
+    pk: 'MLS1::Backcountry Cabins',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    revenueFamily: 9.99,
+    peopleAdult: 9,
+    peopleFamily: 9,
+    peopleChild: 9,
+    notes: 'Mock legacy notes',
+    legacyData: {
+      legacy_backcountryCabinsTotalAttendancePeople: 9,
+      legacy_backcountryCabinsNetRevenue: 9
+    }
+  }
+
+  public static readonly mockBackcountryCampingRecord_1 = {
+    pk: 'MOC1::Backcountry Camping',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    people: 1,
+    grossCampingRevenue: 1.11,
+    notes: 'Mock notes',
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockBackcountryCampingRecord_Legacy = {
+    pk: 'MLS1::Backcountry Camping',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    grossCampingRevenue: 9.99,
+    notes: 'Mock legacy notes',
+  }
+
+  public static readonly mockBoatingRecord_1 = {
+    pk: 'MOC1::Boating',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    boatAttendaceNightsOnBouys: 1,
+    boatRevenueGross: 1.11,
+    boatAttendanceMiscellaneous: 1,
+    boatAttendanceNightsOnDock: 1,
+    notes: 'Mock notes',
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockBoatingRecord_Legacy = {
+    pk: 'MLS1::Boating',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    boatAttendaceNightsOnBouys: 9,
+    boatAttendanceMiscellaneous: 9,
+    boatAttendanceNightsOnDock: 9,
+    boatRevenueGross: 9.99,
+    notes: 'Mock legacy notes',
+    legacyData: {
+      legacy_boatingTotalAttendancePeople: 9,
+      legacy_boatingTotalNetRevenue: 9.99
+    }
+  }
+
+  public static readonly mockDayUseRecord_1 = {
+    pk: 'MOC1::Day Use',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    picnicRevenueShelter: 1.11,
+    peopleAndVehiclesBus: 1,
+    picnicShelterPeople: 1,
+    picnicRevenueGross: 1.11,
+    notes: 'Mock notes',
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockDayUseRecord_Legacy = {
+    pk: 'MLS1::Day Use',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    picnicRevenueShelter: 9.99,
+    peopleAndVehiclesBus: 9,
+    picnicShelterPeople: 9,
+    picnicRevenueGross: 9.99,
+    notes: 'Mock legacy notes',
+    legacyData: {
+      legacy_dayUseTotalPeopleAndVehiclesAttendancePeople: 9,
+      legacy_dayUseMiscGrossRevenue: 9.99,
+      legacy_dayUseMiscNetRevenue: 9.99,
+      legacy_dayUsePicnicShelterNetRevenue: 9.99,
+      legacy_dayUsePicnicShelterVarianceNote: 'Mock picnic shelter notes',
+      legacy_dayUseTotalNetRevenue: 9.99,
+      legacy_dayUseTotalGrossRevenue: 9.99,
+      legacy_dayUseTotalAttendancePeople: 9,
+    }
+  }
+
+  public static readonly mockFrontcountryCabinsRecord_1 = {
+    pk: 'MOC1::Frontcountry Cabins',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    totalAttendanceParties: 1,
+    revenueGrossCamping: 1.11,
+    notes: 'Mock notes',
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockFrontcountryCabinsRecord_Legacy = {
+    pk: 'MLS1::Frontcountry Cabins',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    totalAttendanceParties: 9,
+    revenueGrossCamping: 9.99,
+    notes: 'Mock legacy notes',
+    legacyData: {}
+  }
+
+  public static readonly mockFrontcountryCampingRecord_1 = {
+    pk: 'MOC1::Frontcountry Camping',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    campingPartyNightsAttendanceStandard: 1,
+    campingPartyNightsAttendanceSenior: 1,
+    campingPartyNightsAttendanceSocial: 1,
+    campingPartyNightsAttendanceLongStay: 1,
+    secondCarsAttendanceStandard: 1,
+    secondCarsAttendanceSenior: 1,
+    secondCarsAttendanceSocial: 1,
+    secondCarsRevenueGross: 1.11,
+    notes: 'Mock notes',
+    otherRevenueGrossSani: 1.11,
+    otherRevenueShower: 1.11,
+    otherRevenueElectrical: 1.11,
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockFrontcountryCampingRecord_Legacy = {
+    pk: 'MLS1::Frontcountry Camping',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    campingPartyNightsAttendanceStandard: 9,
+    campingPartyNightsAttendanceSenior: 9,
+    campingPartyNightsAttendanceSocial: 9,
+    campingPartyNightsAttendanceLongStay: 9,
+    secondCarsAttendanceStandard: 9,
+    secondCarsAttendanceSenior: 9,
+    secondCarsAttendanceSocial: 9,
+    secondCarsRevenueGross: 9.99,
+    notes: 'Mock legacy notes',
+    otherRevenueGrossSani: 9.99,
+    otherRevenueShower: 9.99,
+    otherRevenueElectrical: 9.99,
+    legacyData: {
+      legacy_frontcountryCampingTotalCampingParties: 9,
+      legacy_frontcountryCampingTotalCampingGrossRevenue: 9.99,
+      legacy_frontcountryCampingTotalCampingNetRevenue: 9.99,
+      legacy_frontcountryCampingTotalSecondCarsAttendance: 9,
+      legacy_frontcountryCampingSecondCarsNetRevenue: 9.99,
+      legacy_dayUseMiscSaniStationNetRevenue: 9.99,
+      legacy_dayUseMiscShowerNetRevenue: 9.99,
+    }
+  }
+
+  public static readonly mockGroupCampingRecord_1 = {
+    pk: 'MOC1::Group Camping',
+    sk: '202301',
+    date: '202301',
+    parkName: 'Mock Park 1',
+    subAreaName: 'Mock SubArea 1',
+    orcs: 'MOC1',
+    lastUpdated: '2023-01-01T00:00:00.000Z',
+    isLocked: false,
+    youthRateGroupsAttendancePeople: 1,
+    youthRateGroupsAttendanceGroupNights: 1,
+    youthRateGroupsRevenueGross: 1.11,
+    standardRateGroupsTotalPeopleAdults: 1,
+    standardRateGroupsTotalPeopleYouth: 1,
+    standardRateGroupsTotalPeopleKids: 1,
+    standardRateGroupsTotalPeopleStandard: 1,
+    standardRateGroupsRevenueGross: 1.11,
+    notes: 'Mock notes',
+    // TODO: update config
+    config: {}
+  }
+
+  public static readonly mockGroupCampingRecord_Legacy = {
+    pk: 'MLS1::Group Camping',
+    sk: '201901',
+    date: '201901',
+    parkName: 'Mock Legacy Park 1',
+    subAreaName: 'Mock Legacy SubArea 1',
+    orcs: 'MLP1',
+    lastUpdated: '2019-01-01T00:00:00.000Z',
+    isLocked: true,
+    isLegacy: true,
+    youthRateGroupsAttendancePeople: 9,
+    youthRateGroupsAttendanceGroupNights: 9,
+    youthRateGroupsRevenueGross: 9.99,
+    standardRateGroupsTotalPeopleAdults: 9,
+    standardRateGroupsTotalPeopleYouth: 9,
+    standardRateGroupsTotalPeopleKids: 9,
+    standardRateGroupsTotalPeopleStandard: 9,
+    standardRateGroupsRevenueGross: 9.99,
+    notes: 'Mock legacy notes',
+    legacyData: {
+      legacy_groupCampingStandardTotalAttendancePeople: 9,
+      legacy_groupCampingTotalNetRevenue: 9.99,
+      legacy_groupCampingTotalGrossRevenue: 9.99,
+    }
+  }
+}

--- a/src/assets/themes/_variables.scss
+++ b/src/assets/themes/_variables.scss
@@ -5,6 +5,7 @@ $lightblue: #ecf6ff;
 $secondary-nav: #38598a;
 $primary-blue: #036;
 $calc-blue: #C7E3FD;
+$calc-grey: #e4e4e4;
 $calc-green: #AEE5BA;
 $form-grey: #F2F2F2;
 $form-invalid: #d8292f;


### PR DESCRIPTION
### Jira Ticket:
BRS-972

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-972

### Description:

NOTE: https://github.com/bcgov/bcparks-ar-api/pull/136 must be merged first to tell the API to surface legacy records.

Adding accordion changes to accommodate the `legacy` versions of the existing 7 activities. Minor changes to the search filters and some common components to improve reusability.

Variable name change in `dataService`: changed `getItemValue` to `watchItem` to bring A&R more in line with DUP. `watchItem` now returns a `BehaviourSubject` to subscribe to, and `getItemValue` returns the current value of said `BehaviourSubject`. Obviously this change had to occur in many parts of the code base which has led to the artificial ballooning of files touched.

Updates to `activityService`: Now that there are historical records in the system, we can't always rely on the subarea object to inform the front end which activity accordions to show. Records may exist for activities that have since been removed from the subarea. Therefore, when we do a record search now, we much do 1 database query for each of the existing 7 activities to see if a record exists. It is not necessarily efficient (3.5 read units/search), but it can be improved when research has been completed on finding a way to determine which records have NOT been entered yet.