### PR TITLE
NOBUG: Security updates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "guid-typescript": "^1.0.9",
     "jquery": "^3.6.0",
     "keycloak-angular": "^13.0.0",
-    "keycloak-js": "^20.0.2",
+    "keycloak-js": "21.0.2",
     "moment": "^2.29.4",
     "ngx-bootstrap": "^10.2.0",
     "ngx-toastr": "^16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4557,10 +4557,10 @@ keycloak-angular@^13.0.0:
   dependencies:
     tslib "^2.3.0"
 
-keycloak-js@^20.0.2:
-  version "20.0.2"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-20.0.2.tgz#31c337a33eb44fc2aaaed342519cc6d5e959e4bd"
-  integrity sha512-RPLeBdrsB4ybc2tWL5R+tUqdUd62ytZLVT7AWcCCqMWKuQ0AbmrOtGaPnnWMzS/3XJH447nDq1ulUOGzpj41LQ==
+keycloak-js@21.0.2:
+  version "21.0.2"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-21.0.2.tgz#1d3c2079d3c23850df4f253a868926861c51c488"
+  integrity sha512-i05i3VBPhQ867EgjA+OYPlf8YUPiUwtrU2zv4j8tvZIdRvhJY8f+mp1ZvRJl/GMRb+XhJs9BDknyBMrIspwDkw==
   dependencies:
     base64-js "^1.5.1"
     js-sha256 "^0.9.0"


### PR DESCRIPTION
This updates keycloak-js to latests 'working' version.  The very latest is a broken package on npm.