### PR TITLE
BRS-898: review data page barebones

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jquery": "^3.6.0",
     "keycloak-angular": "^13.0.0",
     "keycloak-js": "21.1.1",
+    "luxon": "^3.3.0",
     "moment": "^2.29.4",
     "ngx-bootstrap": "^10.2.0",
     "ngx-toastr": "^16.0.1",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import { FormResolver } from './resolvers/form.resolver';
 import { SubAreaResolver } from './resolvers/sub-area.resolver';
 import { LockRecordsComponent } from './lock-records/lock-records.component';
 import { LockRecordsResolver } from './resolvers/lock-records.resolver';
+import { VarianceSearchComponent } from './variance-search/variance-search.component';
 
 const routes: Routes = [
   {
@@ -137,6 +138,16 @@ const routes: Routes = [
       breadcrumb: 'Lock Records',
     },
     resolve: [LockRecordsResolver],
+  },
+  {
+    path: 'review-data',
+    component: VarianceSearchComponent,
+    canActivate: [AuthGuard],
+    data: {
+      label: 'Review Data',
+      breadcrumb: 'Review Data',
+    },
+    resolve: [SubAreaResolver],
   },
   {
     path: 'unauthorized',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoadingService } from './services/loading.service';
 import { LockRecordsModule } from './lock-records/lock-records.module';
+import { VarianceSearchModule } from './variance-search/variance-search.module';
 
 export function initConfig(
   configService: ConfigService,
@@ -65,6 +66,7 @@ export function initConfig(
     InfiniteLoadingBarModule,
     BrowserAnimationsModule,
     ToastrModule.forRoot(),
+    VarianceSearchModule
   ],
   providers: [
     {

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -67,6 +67,10 @@ export class AuthGuard implements CanActivate {
       return this.router.parseUrl('/');
     }
 
+    if (!this.keycloakService.isAllowed('review-data') && state.url === '/review-data') {
+      return this.router.parseUrl('/');
+    }
+
     // Show the requested page.
     return true;
   }

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -28,12 +28,12 @@ describe('HomeComponent', () => {
     expect(component.cardConfig.length).toBe(1);
   });
 
-    it('should create and have three cards', () => {
+    it('should create and have four cards', () => {
     mockKeycloakService.isAllowed.and.returnValue(true);
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
     expect(component).toBeTruthy();
-    expect(component.cardConfig.length).toBe(3);
+    expect(component.cardConfig.length).toBe(4);
   });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -34,6 +34,14 @@ export class HomeComponent {
         navigation: 'lock-records',
       });
     }
+    if (keyCloakService.isAllowed('review-data')) {
+      this.cardConfig.push({
+        cardHeader: 'Review Data',
+        cardTitle: 'Review variances in data',
+        cardText: 'Use this section to review variance records.',
+        navigation: 'review-data',
+      });
+    }
 
   }
 }

--- a/src/app/services/keycloak.service.ts
+++ b/src/app/services/keycloak.service.ts
@@ -153,9 +153,27 @@ export class KeycloakService {
    * @memberof KeycloakService
    */
   isAllowed(service): boolean {
-    if (service !== 'lock-records') {
+    // admin only routes
+    let adminOnlyRoutes = [
+      'lock-records',
+      'review-data',
+    ]
+    if (!adminOnlyRoutes.find(route => route === service)) {
       return true;
     }
+
+    // block these routes in prod
+    let blockedInProd = [
+      'review-data'
+    ]
+
+    if (this.configService['configuration'].ENVIRONMENT === 'prod') {
+      // we are in prod
+      if (blockedInProd.find(route => route === service)) {
+        return false;
+      }
+    }
+
     const token = this.getToken();
 
     if (!token) {

--- a/src/app/services/keycloak.service.ts
+++ b/src/app/services/keycloak.service.ts
@@ -162,18 +162,6 @@ export class KeycloakService {
       return true;
     }
 
-    // block these routes in prod
-    let blockedInProd = [
-      'review-data'
-    ]
-
-    if (this.configService['configuration'].ENVIRONMENT === 'prod') {
-      // we are in prod
-      if (blockedInProd.find(route => route === service)) {
-        return false;
-      }
-    }
-
     const token = this.getToken();
 
     if (!token) {

--- a/src/app/services/sub-area.service.spec.ts
+++ b/src/app/services/sub-area.service.spec.ts
@@ -44,7 +44,7 @@ describe('SubAreaService', () => {
     loadingService = TestBed.inject(LoadingService);
     loggerService = TestBed.inject(LoggerService);
     apiService = TestBed.inject(ApiService);
-    dataServiceSpy = spyOn(subareaService['dataService'], 'clearItemValue');
+    dataServiceSpy;
     loadingServiceAddSpy = spyOn(
       subareaService['loadingService'],
       'addToFetchList'
@@ -84,32 +84,41 @@ describe('SubAreaService', () => {
     expect(fetchActivityDetailsSpy).toHaveBeenCalledTimes(Constants.ActivityTypes.length);
   });
 
+  it('fetches subareas by orcs', async () => {
+    let setDataServiceSpy = spyOn(subareaService['dataService'], 'setItemValue');
+    apiServiceSpy = spyOn(subareaService['apiService'], 'get').and.returnValue(new BehaviorSubject({data:['valid_Data']}));
+    let res = await subareaService.fetchSubareasByOrcs('0001');
+    expect(res).toEqual({data: ['valid_Data']});
+    expect(setDataServiceSpy).toHaveBeenCalledTimes(1);
+  
+  })
 
   it('clears accordion cache', async () => {
+    let clearDataServiceSpy = spyOn(subareaService['dataService'], 'clearItemValue');
     subareaService.clearAccordionCache();
-    expect(dataServiceSpy).toHaveBeenCalledTimes(8);
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledTimes(8);
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ENTER_DATA_SUB_AREA
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_BACKCOUNTRY_CABINS
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_BACKCOUNTRY_CAMPING
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_BOATING
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_DAY_USE
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_FRONTCOUNTRY_CABINS
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_FRONTCOUNTRY_CAMPING
     );
-    expect(dataServiceSpy).toHaveBeenCalledWith(
+    expect(clearDataServiceSpy).toHaveBeenCalledWith(
       Constants.dataIds.ACCORDION_GROUP_CAMPING
     );
   });

--- a/src/app/services/sub-area.service.ts
+++ b/src/app/services/sub-area.service.ts
@@ -75,6 +75,30 @@ export class SubAreaService {
     this.loadingService.removeToFetchList(id);
   }
 
+  async fetchSubareasByOrcs(orcs) {
+    // return all subareas belonging to the given orcs.
+    let res;
+    let errorSubject = '';
+    this.loadingService.addToFetchList(Constants.dataIds.CURRENT_SUBAREA_LIST);
+    try {
+      this.loggerService.debug(`${orcs} - subareas GET: ${orcs}`);
+      res = await firstValueFrom(this.apiService.get('park', { orcs: orcs }));
+      this.dataService.setItemValue(Constants.dataIds.CURRENT_SUBAREA_LIST, res.data);
+    } catch (error) {
+      this.loggerService.error(`${error}`);
+      this.toastService.addMessage(
+        `Please refresh the page.`,
+        `Error getting ${errorSubject}`,
+        ToastTypes.ERROR
+      );
+      this.eventService.setError(
+        new EventObject(EventKeywords.ERROR, String(error), 'Sub-area Service')
+      );
+    }
+    this.loadingService.removeToFetchList(Constants.dataIds.CURRENT_SUBAREA_LIST);
+    return res;
+  }
+
   public clearAccordionCache() {
     this.dataService.clearItemValue(Constants.dataIds.ENTER_DATA_SUB_AREA);
     this.dataService.clearItemValue(

--- a/src/app/services/variance.service.spec.ts
+++ b/src/app/services/variance.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+
+import { VarianceService } from './variance.service';
+import { LoggerService } from './logger.service';
+import { ConfigService } from './config.service';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { Constants } from '../shared/utils/constants';
+import { BehaviorSubject } from 'rxjs';
+
+describe('VarianceService', () => {
+  let service: VarianceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LoggerService,
+        ConfigService,
+        HttpClient,
+        HttpHandler
+      ]
+    });
+    service = TestBed.inject(VarianceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch variances', async () => {
+    // dont fetch if minimum fields are not provided
+    const badParams = {};
+    let dataServiceSpy = spyOn(service['dataService'], 'setItemValue');
+    let apiServiceSpy = spyOn(service['apiService'], 'get').and.returnValue(new BehaviorSubject({ data: 'success' }));
+    await service.fetchVariance(badParams);
+    expect(dataServiceSpy).not.toHaveBeenCalled();
+    // call with parameters
+    const goodParams = {
+      subAreaId: '1111',
+      activity: 'activity',
+      date: '202306',
+      lastEvaluatedKey: '12345'
+    }
+    await service.fetchVariance(goodParams);
+    expect(apiServiceSpy).toHaveBeenCalledOnceWith('variance', goodParams);
+    expect(dataServiceSpy).toHaveBeenCalledOnceWith(
+      Constants.dataIds.VARIANCE_LIST,
+      'success'
+    );
+  })
+
+  it('should throw error if fetch variance fails', async () => {
+    let dataServiceSpy = spyOn(service['dataService'], 'setItemValue');
+    let errorThrower = spyOn(service['apiService'], 'get').and.callFake(() => {
+      throw new Error('error');
+    });
+    await service.fetchVariance({ subAreaId: '1111', activity: 'activity', date: '202306' })
+    expect(errorThrower).toHaveBeenCalledTimes(1);
+    expect(dataServiceSpy).toHaveBeenCalledOnceWith(
+      Constants.dataIds.VARIANCE_LIST,
+      'error'
+    );
+  });
+});

--- a/src/app/services/variance.service.ts
+++ b/src/app/services/variance.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+import { Constants } from '../shared/utils/constants';
+import { LoadingService } from './loading.service';
+import { LoggerService } from './logger.service';
+import { firstValueFrom } from 'rxjs';
+import { ApiService } from './api.service';
+import { DataService } from './data.service';
+import { ToastService, ToastTypes } from './toast.service';
+import { EventKeywords, EventObject, EventService } from './event.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class VarianceService {
+
+  constructor(
+    private loadingService: LoadingService,
+    private loggerService: LoggerService,
+    private apiService: ApiService,
+    private dataService: DataService,
+    private toastService: ToastService,
+    private eventService: EventService
+  ) { }
+
+  async fetchVariance(params) {
+    this.loadingService.addToFetchList(Constants.dataIds.VARIANCE_LIST);
+    let res;
+    let errorSubject = '';
+    // subarea and activity are mandatory fields
+    if (params.subAreaId && params.activity) {
+      try {
+        errorSubject = 'variance';
+        this.loggerService.debug('Variance GET');
+
+        // 1. organize filter parameters
+
+        let apiParams = {
+          subAreaId: params.subAreaId,
+          activity: params.activity,
+        };
+
+        // set base api params
+        if (params.date){
+          apiParams['date'] = params.date;
+        }
+
+        if (params.lastEvaluatedKey) {
+          apiParams['lastEvaluatedKey'] = params.lastEvaluatedKey;
+        }
+
+        // 2. fetch data
+        res = await firstValueFrom(this.apiService.get('variance', apiParams));
+        this.dataService.setItemValue(Constants.dataIds.VARIANCE_LIST, res.data);
+      } catch (error) {
+        this.loggerService.error(`Error fetching ${errorSubject}: ${error}`);
+        this.toastService.addMessage(
+          `Variance fetch failed.`,
+          `Error getting ${errorSubject}`,
+          ToastTypes.ERROR
+        );
+        this.eventService.setError(
+          new EventObject(EventKeywords.ERROR, String(error), 'Variance Service')
+        );
+        this.dataService.setItemValue(Constants.dataIds.VARIANCE_LIST, 'error');
+      }
+    }
+    this.loadingService.removeToFetchList(Constants.dataIds.VARIANCE_LIST);
+  }
+}

--- a/src/app/shared/components/forms/picklist/picklist.component.html
+++ b/src/app/shared/components/forms/picklist/picklist.component.html
@@ -1,5 +1,5 @@
 <label *ngIf="label" for="{{ id }}" class="fw-bold">{{ label
-  }}<span *ngIf="required" class="text-danger">&nbsp;*</span></label>
+  }}<span *ngIf="isRequired()" class="text-danger">&nbsp;*</span></label>
 
 <div class="input-group mb-3">
   <span *ngIf="icon" class="input-group-text" [ngClass]="icon"><i class="bi"></i></span>

--- a/src/app/shared/components/forms/picklist/picklist.component.html
+++ b/src/app/shared/components/forms/picklist/picklist.component.html
@@ -1,0 +1,15 @@
+<label *ngIf="label" for="{{ id }}" class="fw-bold">{{ label
+  }}<span *ngIf="required" class="text-danger">&nbsp;*</span></label>
+
+<div class="input-group mb-3">
+  <span *ngIf="icon" class="input-group-text" [ngClass]="icon"><i class="bi"></i></span>
+  <select name="{{ id }}" id="{{ id }}"
+    class="form-control" [formControl]="control" [value]="control?.value">
+    <option selected *ngIf="placeholder" value="null">
+      {{ placeholder }}
+    </option>
+    <option *ngFor="let option of options; index as i" value="{{ option?.value }}" [disabled]="option?.disabled">
+      {{ option?.display }}
+    </option>
+  </select>
+</div>

--- a/src/app/shared/components/forms/picklist/picklist.component.scss
+++ b/src/app/shared/components/forms/picklist/picklist.component.scss
@@ -1,0 +1,8 @@
+select {
+  background: url("data:image/svg+xml,<svg height='10px' width='10px' viewBox='0 0 16 16' fill='%23000000' xmlns='http://www.w3.org/2000/svg'><path d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>") no-repeat white;
+  background-position: calc(100% - 0.75rem) center !important;
+  -moz-appearance:none !important;
+  -webkit-appearance: none !important; 
+  appearance: none !important;
+  padding-right: 2rem !important;
+}

--- a/src/app/shared/components/forms/picklist/picklist.component.spec.ts
+++ b/src/app/shared/components/forms/picklist/picklist.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PicklistComponent } from './picklist.component';
+import { UntypedFormControl, Validators } from '@angular/forms';
+
+describe('PicklistComponent', () => {
+  let component: PicklistComponent;
+  let fixture: ComponentFixture<PicklistComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PicklistComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PicklistComponent);
+    component = fixture.componentInstance;
+    component.options = [
+      {
+        value: 'test',
+        display: 'test'
+      },
+      {
+        value: 'test2',
+        display: 'test2'
+      }
+    ]
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should determine if control is required', async () => {
+    component.control = new UntypedFormControl;
+    expect(component.isRequired()).toBe(false);
+    component.control.addValidators([Validators.required])
+    component.control.updateValueAndValidity();
+    expect(component.isRequired()).toBe(true)
+  })
+
+  it('should set control ability', async () => {
+    component.setDisabled(true);
+    expect(component.control.disabled).toBe(true);
+    component.setDisabled(false);
+    expect(component.control.enabled).toBe(true);
+  })
+});

--- a/src/app/shared/components/forms/picklist/picklist.component.ts
+++ b/src/app/shared/components/forms/picklist/picklist.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+import { UntypedFormControl, Validators } from '@angular/forms';
+import { BehaviorSubject } from 'rxjs';
+
+@Component({
+  selector: 'app-picklist',
+  templateUrl: './picklist.component.html',
+  styleUrls: ['./picklist.component.scss']
+})
+export class PicklistComponent {
+  @Input() control = new UntypedFormControl;
+  @Input() label;
+  @Input() icon;
+  @Input() id;
+  @Input() set disabled(value: boolean) {
+    this.setDisabled(value)
+  }
+  public get disabled() { 
+    return this._disabled.value;
+  }
+  @Input() set options(value: any) {
+    this._options.next(value);
+  }
+  public get options() {
+    return this._options.value || [];
+  }
+  @Input() placeholder = '';
+  @Input() required = false;
+
+  public _options = new BehaviorSubject<any>({ value: null, display: null });
+  public _disabled = new BehaviorSubject<any>(false);
+
+  isRequired(): boolean {
+    return this.control.hasValidator(Validators.required)
+  }
+
+  setDisabled(value: boolean) {
+    this._disabled.next(value);
+    if (value) {
+      this.control.disable();
+    } else {
+      this.control.enable();
+    }
+  }
+}

--- a/src/app/shared/components/forms/picklist/picklist.module.ts
+++ b/src/app/shared/components/forms/picklist/picklist.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { PicklistComponent } from './picklist.component';
+
+@NgModule({
+  declarations: [
+    PicklistComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule
+  ],
+  exports: [
+    PicklistComponent
+  ]
+})
+export class PicklistModule { }

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -31,6 +31,8 @@ export class SidebarComponent implements OnDestroy {
         return keyCloakService.isAllowed('export-reports');
       } else if (obj.path === 'lock-records') {
         return keyCloakService.isAllowed('lock-records');
+      } else if (obj.path === 'review-data') {
+        return keyCloakService.isAllowed('review-data');
       } else if (obj.path === 'login') {
         return keyCloakService.isAuthenticated() ? false : true;
       } else {

--- a/src/app/shared/components/typeahead/typeahead.component.html
+++ b/src/app/shared/components/typeahead/typeahead.component.html
@@ -1,4 +1,6 @@
-<label for="{{ id }}" class="fw-bold">{{ label }}</label>
+<label for="{{ id }}" class="fw-bold">{{ label }}
+  <span class="text-danger" *ngIf="isRequired()">*</span>
+</label>
 <div class="input-group">
   <input
   id="{{ id }}"
@@ -15,7 +17,7 @@
   [disabled]="disabled ? true : false"
   [resultTemplate]="rt"
   />
-  <span class="input-group-text border-start-0 clear-button" [ngStyle]="{'background-color': disabled ? '#e9ecef' : 'white'}" (click)="setControlValue(null)" type="button">
+  <span class="input-group-text border-start-0 clear-button" [ngStyle]="{'background-color': disabled ? '#e9ecef' : 'white'}" (click)="clear()" type="button">
       <i class="bi bi-x-lg"></i>
   </span>
 </div>

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -2,6 +2,7 @@ export class Constants {
   public static readonly dataIds = {
     ENTER_DATA_PARK: 'enterDataPark',
     ENTER_DATA_SUB_AREA: 'enterDataSubArea',
+    CURRENT_SUBAREA_LIST: 'current-subarea-list',
     ACCORDION_FRONTCOUNTRY_CAMPING: 'accordion-Frontcountry Camping',
     ACCORDION_FRONTCOUNTRY_CABINS: 'accordion-Frontcountry Cabins',
     ACCORDION_DAY_USE: 'accordion-Day Use',
@@ -15,6 +16,8 @@ export class Constants {
     ENTER_DATA_URL_PARAMS: 'enter-data-url-params',
     EXPORT_ALL_POLLING_DATA: 'export-all-polling-data',
     LOCK_RECORDS_FISCAL_YEARS_DATA: 'lock-records-fiscal-years-data',
+    VARIANCE_FILTERS: 'variance-filters',
+    VARIANCE_LIST: 'variance-list',
   };
 
   public static readonly ApplicationRoles: any = {

--- a/src/app/shared/utils/mock.data.ts
+++ b/src/app/shared/utils/mock.data.ts
@@ -382,4 +382,31 @@ export class MockData {
       legacy_groupCampingTotalGrossRevenue: 9.99,
     }
   }
+
+  public static readonly mockVarianceRecord_1 = {
+    activity: 'Day Use',
+    date: '202306',
+    fields: ['peopleAndVehiclesVehicle'],
+    orcs: 'MOC1',
+    parkName: 'Mock Park 1',
+    pk: 'variance::MOC1::Day Use',
+    sk: '202306',
+    resolved: false,
+    subAreaId: 'MOC1',
+    subAreaName: 'Mock SubArea 1',
+  }
+
+  public static readonly mockVarianceRecord_2 = {
+    activity: 'Frontcountry Camping',
+    date: '202306',
+    fields: ['campingPartyNightsRevenueGross'],
+    orcs: 'MOC1',
+    parkName: 'Mock Park 1',
+    pk: 'variance::MOC1::Frontcountry Camping',
+    sk: '202306',
+    resolved: true,
+    subAreaId: 'MOC1',
+    subAreaName: 'Mock SubArea 1',
+  }
+
 }

--- a/src/app/shared/utils/variance-utils.spec.ts
+++ b/src/app/shared/utils/variance-utils.spec.ts
@@ -1,6 +1,6 @@
 import { VarianceUtils } from './variance-utils';
 
-fdescribe('Variance Util Tests', () => {
+describe('Variance Util Tests', () => {
   it('should trigger variance', async () => {
     const value = VarianceUtils.calculateVariance(8, 8, 8, 10, 0.2);
     expect(value).toEqual({

--- a/src/app/variance-search/variance-filters/variance-filters.component.html
+++ b/src/app/variance-search/variance-filters/variance-filters.component.html
@@ -1,0 +1,33 @@
+<div class="bg-filter p-3">
+  <section>
+    <div class="row">
+      <!-- wait for controls to load before rendering typeaheads -->
+      <div class="col-sm-12 col-md-6 col-lg">
+        <app-typeahead *ngIf="fields.park" [control]="fields.park" [id]="'park-typeahead'" [data]="parks"
+          [label]="'Park'" (cleared)="parkCleared()" required></app-typeahead>
+      </div>
+      <div class="col-sm-12 col-md-6 col-lg">
+        <app-typeahead *ngIf="fields.subarea" [control]="fields.subarea" [id]="'subareas-typeahead'" [data]="subAreas" (cleared)="parkCleared()"
+          [disabled]="!fields.park.value" [label]="'Subarea'"></app-typeahead>
+      </div>
+      <div *ngIf="activityOptions" class="col-sm-12 col-md-6 col-lg">
+        <app-picklist [control]="fields?.activity" [label]="'Activity'" [options]="activityOptions" [disabled]="!fields.subarea.value">
+        </app-picklist>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-12 col-md-6 col-lg">
+        <label class="fw-bold">Date</label>
+        <input [(ngModel)]="modelDate" autocomplete="off" class="form-control" name="date" placeholder="Select date"
+          bsDatepicker [maxDate]="maxDate" [bsConfig]="{ dateInputFormat: 'MM/YYYY' }"
+          (onShown)="onOpenCalendar($event)" (ngModelChange)="dateChange($event)" />
+      </div>
+      <div class="col-sm-12 col-md-6 col-lg">
+        <!-- Empty column to enforce correct spacing -->
+      </div>
+      <div class="col-sm-12 col-md-6 col-lg">
+        <div class="btn btn-primary w-100 mt-4" (click)="submit()" disabled="form.invalid">Filter</div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/app/variance-search/variance-filters/variance-filters.component.html
+++ b/src/app/variance-search/variance-filters/variance-filters.component.html
@@ -26,7 +26,7 @@
         <!-- Empty column to enforce correct spacing -->
       </div>
       <div class="col-sm-12 col-md-6 col-lg">
-        <div class="btn btn-primary w-100 mt-4" (click)="submit()" disabled="form.invalid">Filter</div>
+        <button class="btn btn-primary w-100 mt-4" (click)="submit()" [disabled]="form.invalid">Filter</button>
       </div>
     </div>
   </section>

--- a/src/app/variance-search/variance-filters/variance-filters.component.scss
+++ b/src/app/variance-search/variance-filters/variance-filters.component.scss
@@ -1,0 +1,5 @@
+@import "src/assets/themes/variables";
+
+.bg-filter {
+  background-color: $calc-blue;
+}

--- a/src/app/variance-search/variance-filters/variance-filters.component.spec.ts
+++ b/src/app/variance-search/variance-filters/variance-filters.component.spec.ts
@@ -1,0 +1,108 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VarianceFiltersComponent } from './variance-filters.component';
+import { ChangeDetectorRef } from '@angular/core';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { ConfigService } from 'src/app/services/config.service';
+import { Validators } from '@angular/forms';
+import { MockData } from 'src/app/shared/utils/mock.data';
+
+describe('VarianceFiltersComponent', () => {
+  let component: VarianceFiltersComponent;
+  let fixture: ComponentFixture<VarianceFiltersComponent>;
+
+  let subareas = [
+    MockData.mockSubArea_1,
+    MockData.mockSubArea_2
+  ]
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [VarianceFiltersComponent],
+      providers: [
+        ChangeDetectorRef,
+        HttpClient,
+        HttpHandler,
+        ConfigService
+      ]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(VarianceFiltersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(Object.keys(component.form.controls).length).toEqual(4);
+    expect(Object.keys(component.fields).length).toEqual(4);
+    for (const field in component.fields) {
+      if (field !== 'date') {
+        expect(component.form.controls[field].hasValidator(Validators.required)).toEqual(true);
+      }
+      expect(component.form.controls[field].value).toEqual(null);
+      expect(component.form.controls[field].disabled).toEqual(false);
+    }
+  });
+
+  it('sets the date', async () => {
+    // in the past
+    component.maxDate = new Date('January 1, 2023');
+    let pastYYYYMM = '202206';
+    let pastDate = component['utils'].convertYYYYMMToJSDate(pastYYYYMM);
+    component.setDate(pastYYYYMM);
+    expect(component.previousDateChosen).toEqual(pastDate);
+    expect(component.modelDate).toEqual(pastDate);
+    // in the future
+    jasmine.clock().install();
+    let futureYYYYMM = '202307';
+    component.setDate(futureYYYYMM);
+    jasmine.clock().tick(50)
+    expect(component.modelDate).toEqual(pastDate);
+    jasmine.clock().uninstall();
+  });
+
+  it('builds subarea options', async () => {
+    component.buildSubareaOptions(subareas);
+    expect(component.subAreas).toEqual([
+      {
+        key: MockData.mockSubArea_1.sk,
+        value: MockData.mockSubArea_1,
+        display: MockData.mockSubArea_1.subAreaName,
+      },
+      {
+        key: MockData.mockSubArea_2.sk,
+        value: MockData.mockSubArea_2,
+        display: MockData.mockSubArea_2.subAreaName,
+      },
+    ])
+  })
+
+  it('builds activity options', async () => {
+    component.buildActivityOptions({value: MockData.mockSubArea_1});
+    expect(component.activityOptions.length).toEqual(MockData.mockSubArea_1.activities.length)
+  })
+
+  it('clears fields', async () => {
+    component.fields.subarea.setValue({value: MockData.mockSubArea_1});
+    component.fields.activity.setValue({value: 'mockActivity_1'});
+    component.parkCleared();
+    expect(component.fields.subarea.value).toEqual(null);
+    expect(component.fields.activity.value).toEqual(null);
+  })
+
+  it('submits the form', async () => {
+    let varianceSpy = spyOn(component['varianceService'], 'fetchVariance');
+    component.fields.subarea.setValue({value: MockData.mockSubArea_1});
+    component.fields.activity.setValue('mockActivity_1');
+    component.submit();
+    expect(varianceSpy).toHaveBeenCalledOnceWith({
+      subarea: MockData.mockSubArea_1,
+      subAreaId: MockData.mockSubArea_1.sk,
+      activity: 'mockActivity_1',
+      date: null,
+      park: undefined
+    });
+  })
+});

--- a/src/app/variance-search/variance-filters/variance-filters.component.ts
+++ b/src/app/variance-search/variance-filters/variance-filters.component.ts
@@ -1,0 +1,204 @@
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormControl, Validators } from '@angular/forms';
+import { Utils } from 'src/app/shared/utils/utils';
+import { Subject, Subscription, takeUntil } from 'rxjs';
+import { DataService } from 'src/app/services/data.service';
+import { Constants } from 'src/app/shared/utils/constants';
+import { SubAreaService } from 'src/app/services/sub-area.service';
+import { VarianceService } from 'src/app/services/variance.service';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-variance-filters',
+  templateUrl: './variance-filters.component.html',
+  styleUrls: ['./variance-filters.component.scss']
+})
+export class VarianceFiltersComponent implements OnInit, OnDestroy {
+  public form;
+  public fields: any = {};
+  public subscriptions = new Subscription();
+
+  private utils = new Utils();
+
+  public urlParams;
+  public modelDate;
+  public maxDate = new Date();
+  public previousDateChosen;
+  public lastEvaluatedKey = null;
+  public parks: any[] = [];;
+  public subAreas: any[] = [];;
+  public activityOptions: any[] = [];
+
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private dataService: DataService,
+    private subareaService: SubAreaService,
+    private varianceService: VarianceService,
+    private cd: ChangeDetectorRef
+  ) {
+    this.subscriptions.add(
+      this.dataService.watchItem(Constants.dataIds.ENTER_DATA_PARK).subscribe((res) => {
+        if (res) {
+          this.parks = this.utils.convertArrayIntoObjForTypeAhead(res, 'parkName');
+        }
+      })
+    )
+    
+    this.subscriptions.add(
+      this.dataService.watchItem(Constants.dataIds.CURRENT_SUBAREA_LIST).subscribe((res) => {
+        if (res) {
+          this.buildSubareaOptions(res);
+        }
+      })
+    );
+    this.subscriptions.add(
+      this.dataService.watchItem(Constants.dataIds.VARIANCE_LIST).subscribe((res) => {
+        if (res && res.lastEvaluatedKey) {
+          this.lastEvaluatedKey = res.lastEvaluatedKey;
+        } else {
+          this.lastEvaluatedKey = null;
+        }
+      })
+    );
+  }
+
+  ngOnInit() {
+    
+    // build form
+    this.form = this.formBuilder.group({});
+
+    // build controls
+    this.buildFormControls();
+
+    // build fields object
+    for (const control in this.form.controls) {
+      this.fields[control] = this.form.controls[control];
+    }
+
+    // watch for park change to populate subarea field
+    this.fields.park.valueChanges.subscribe((park) => {
+      if (park) {
+        this.subareaService.fetchSubareasByOrcs(park.value.orcs);
+      }
+    })
+
+    // watch for subarea change to populate the subarea field
+    this.fields.subarea.valueChanges.subscribe((subarea) => {
+      if (subarea) {
+        this.buildActivityOptions(subarea);
+      }
+    })
+
+    this.cd.detectChanges();
+  }
+
+  buildFormControls() {
+    let controls = [
+      {
+        key: 'date',
+        default: null
+      },
+      {
+        key: 'activity',
+        validators: [
+          Validators.required
+        ]
+      },
+      {
+        key: 'park',
+        default: null,
+        validators: [
+          Validators.required
+        ]
+      },
+      {
+        key: 'subarea',
+        default: null,
+        validators: [
+          Validators.required
+        ]
+      }
+    ];
+    for (const control of controls) {
+      this.form.addControl(control.key, new UntypedFormControl(control?.default || null));
+      if (control.validators) {
+        this.form.controls[control.key].setValidators(control.validators);
+      }
+    }
+  }
+
+  onOpenCalendar(container) {
+    container.monthSelectHandler = (event: any): void => {
+      container._store.dispatch(container._actions.select(event.date));
+    };
+    container.setViewMode('month');
+  }
+
+  dateChange(event) {
+    this.setDate(this.utils.convertJSDateToYYYYMM(event))
+  }
+
+  setDate(YYYYMM) {
+    this.modelDate = this.utils.convertYYYYMMToJSDate(YYYYMM);
+    if (new Date(this.modelDate) <= this.maxDate) {
+      this.previousDateChosen = this.modelDate;
+      this.form.controls.date.setValue(YYYYMM);
+    } else {
+      setTimeout(() => {
+        this.modelDate = this.previousDateChosen;
+      }, 50);
+    }
+  }
+
+  buildSubareaOptions(subareas) {
+    this.subAreas = [];
+    for (const subarea of subareas) {
+      this.subAreas.push({
+        key: subarea.sk,
+        value: subarea,
+        display: subarea.subAreaName
+      })
+    }
+    // this.fields?.subarea?.setValue(this.subAreas[0] || { value: null, display: null });
+  }
+
+
+  buildActivityOptions(subarea) {
+    this.activityOptions = [];
+    for (const activity of subarea.value?.activities) {
+      let activityKey = activity.replace(/ /g, '');
+      this.activityOptions.push({
+        key: activityKey.toLowerCase(),
+        value: activity,
+        display: activity
+      })
+    }
+  }
+
+  parkCleared() {
+    this.fields?.subarea?.setValue(null);
+    this.fields?.activity?.setValue(null);
+  }
+
+  submit() {
+    // collect form values
+    let queryParams = this.collect();
+    // You currently need date, activity, and subareaid to do a variance search.
+    queryParams.subAreaId = queryParams.subarea?.sk;
+    this.varianceService.fetchVariance(queryParams);
+  }
+
+  collect() {
+    // collect form values
+    let formValues = this.form.value;
+    return {
+      ...formValues,
+      park: formValues.park?.value,
+      subarea: formValues.subarea?.value,
+    }
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+}

--- a/src/app/variance-search/variance-filters/variance-filters.component.ts
+++ b/src/app/variance-search/variance-filters/variance-filters.component.ts
@@ -159,7 +159,7 @@ export class VarianceFiltersComponent implements OnInit, OnDestroy {
         display: subarea.subAreaName
       })
     }
-    // this.fields?.subarea?.setValue(this.subAreas[0] || { value: null, display: null });
+    this.cd.detectChanges();
   }
 
 
@@ -173,6 +173,7 @@ export class VarianceFiltersComponent implements OnInit, OnDestroy {
         display: activity
       })
     }
+    this.cd.detectChanges();
   }
 
   parkCleared() {

--- a/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.html
+++ b/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.html
@@ -1,0 +1,74 @@
+<div class="mx-2 row">
+  <div class="col">
+    <!-- Hide header on small screens -->
+    <div class="d-none d-md-block">
+      <div *ngIf="isHeader" class="d-flex row text-nowrap border border-2 border-white">
+        <div class="fw-bold px-3 pb-1 accordion-header overflow-hidden {{col?.columnClasses}}"
+          *ngFor="let col of rowSchema" [attr.id]="col?.id">
+          <div *ngIf="col?.displayHeader">
+            {{col?.displayHeader}}
+          </div>
+          <!-- <div class="col-1 col-md-2 col-sm-4 col-xs-6" id="resolvedStatusButton">
+          Empty col for resolved status button header
+        </div> -->
+        </div>
+      </div>
+    </div>
+    <div *ngIf="!isHeader" class="d-flex row mt-2 text-nowrap justify-content-between">
+      <!-- Hide accordion on small screens -->
+      <div class="col d-none d-md-block">
+        <div class="row d-flex border border-1 rounded accordion-item align-items-center border-primary">
+          <div *ngFor="let col of rowSchema" class="p-3 overflow-hidden {{col?.columnClasses}}"
+            [ngClass]="col?.divider ? 'border-start border-primary' : ''" [attr.id]="col?.id" data-bs-toggle="collapse"
+            [attr.data-bs-target]="'#p' + rowData?.sk">
+            <div *ngIf="col?.display">
+              <strong class="text-primary">{{col?.display(rowData)}}</strong>
+            </div>
+            <div *ngIf="col?.template">
+              <ng-container [ngTemplateOutlet]="col.template" [ngTemplateOutletContext]="{rowData: rowData}">
+              </ng-container>
+            </div>
+            <div *ngIf="!col?.display && !col?.template">
+              <strong class="text-primary">{{rowData[col?.key]}}</strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Show block view on small screens -->
+  <div class="col-12 d-md-none">
+    <div *ngIf="!isHeader"
+      class="d-flex row mt-2 text-nowrap justify-content-between border border-1 rounded accordion-item align-items-center border-primary">
+      <div class="col border-end border-primary p-2 overflow-hidden">
+        <div *ngFor="let col of rowSchema">
+          <div *ngIf="col?.display">
+            <strong class="text-primary">{{col?.display(rowData)}}</strong>
+          </div>
+          <div *ngIf="!col?.display && !col?.template">
+            <strong class="text-primary">{{rowData[col?.key]}}</strong>
+          </div>
+        </div>
+      </div>
+      <div class="col-auto">
+        <div *ngFor="let col of rowSchema">
+          <div *ngIf="col?.template">
+            <ng-container [ngTemplateOutlet]="col.template" [ngTemplateOutletContext]="{rowData: rowData}">
+            </ng-container>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col col-md-auto d-grid align-items-stretch text-nowrap" id="resolvedStatusButton">
+    <button *ngIf="rowData?.resolved && !isHeader" class="btn btn-success mt-2 overflow-hidden">
+      <i class="bi bi-check-all"></i>
+      Resolved
+    </button>
+    <button *ngIf="!rowData?.resolved && !isHeader" class="btn btn-outline-success mt-2 overflow-hidden">
+      <i class="bi bi-exclamation-circle"></i>
+      Needs Review
+    </button>
+  </div>
+  <hr class="d-md-none mt-4">
+</div>

--- a/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.spec.ts
+++ b/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VarianceAccordionComponent } from './variance-accordion.component';
+
+describe('VarianceAccordionComponent', () => {
+  let component: VarianceAccordionComponent;
+  let fixture: ComponentFixture<VarianceAccordionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VarianceAccordionComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VarianceAccordionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.ts
+++ b/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input, TemplateRef } from '@angular/core';
+
+
+@Component({
+  selector: 'app-variance-accordion',
+  templateUrl: './variance-accordion.component.html',
+  styleUrls: ['./variance-accordion.component.scss']
+})
+export class VarianceAccordionComponent {
+  @Input() rowSchema: any[] = [];
+  @Input() dropDownSchema: any[] = [];
+  @Input() resolvedStatusTemplate: TemplateRef<any>;
+  @Input() rowData: any;
+  @Input() isHeader: boolean = false;
+
+}

--- a/src/app/variance-search/variance-list/variance-list.component.html
+++ b/src/app/variance-search/variance-list/variance-list.component.html
@@ -1,0 +1,25 @@
+<!-- Results table -->
+<div id='variance-list' class="m-4">
+  <div class="d-flex row">
+    <app-variance-accordion [rowSchema]="rowSchema" [isHeader]="true"></app-variance-accordion>
+  </div>
+  <div *ngIf="!loading">
+    <div *ngIf="!variances || variances?.length === 0"
+      class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-3 text-center">
+      No variance records to display.
+    </div>
+    <div *ngFor="let rowData of variances">
+      <app-variance-accordion [rowData]="rowData" [rowSchema]="rowSchema" [resolvedStatusTemplate]="resolvedStatusTemplate"></app-variance-accordion>
+    </div>
+  </div>
+  <div *ngIf="loading"
+    class="bg-light d-flex flex-column h-100 justify-content-center align-items-center p-3 text-center">
+    <span class="spinner-border text-secondary"></span>
+  </div>
+</div>
+
+<ng-template #viewButton let-rowData="rowData">
+  <div class="cursor-pointer text-primary text-center" (click)="viewRecord(rowData)">
+      <strong><i class="bi bi-eye me-2"></i>View</strong>
+  </div>
+</ng-template>

--- a/src/app/variance-search/variance-list/variance-list.component.scss
+++ b/src/app/variance-search/variance-list/variance-list.component.scss
@@ -1,0 +1,3 @@
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/src/app/variance-search/variance-list/variance-list.component.spec.ts
+++ b/src/app/variance-search/variance-list/variance-list.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VarianceListComponent } from './variance-list.component';
+import { MockData } from 'src/app/shared/utils/mock.data';
+
+describe('VarianceListComponent', () => {
+  let component: VarianceListComponent;
+  let fixture: ComponentFixture<VarianceListComponent>;
+
+  let mockVarianceRecords = [MockData.mockVarianceRecord_1, MockData.mockVarianceRecord_2];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [VarianceListComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(VarianceListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(component).toBeTruthy();
+    expect(component.rowSchema.length).toEqual(5);
+  });
+
+  it('should create variance table', async () => {
+    let records = [...mockVarianceRecords];
+    component.createTableRows(records);
+    for (const record of records) {
+      expect(record.subAreaId).toEqual(record.pk.split('::')[1]);
+      expect(record.activity).toEqual(record.pk.split('::')[2]);
+    }
+  })
+
+  it('formats dates', async () => {
+    expect(component.formatDate('202306')).toEqual('June 2023');
+  })
+
+  it('formats activities', async () => {
+    expect(component.formatActivityForUrl('Day Use')).toEqual('day-use');
+  })
+
+  it('navigates to the records url', async () => {
+    let routerSpy = spyOn(component['router'], 'navigate');
+    let record = mockVarianceRecords[0];
+    let route = component.formatActivityForUrl(record.activity);
+    component.viewRecord(record);
+    component.viewRecord(mockVarianceRecords[0]);
+    expect(routerSpy).toHaveBeenCalledWith([`/enter-data/${route}`], {
+      queryParams: {
+        date: record.date,
+        orcs: record.orcs,
+        subAreaId: record.subAreaId,
+        subAreaName: record.subAreaName,
+        parkName: record.parkName,
+      }
+    });
+  });
+
+  it('adjusts the list width on change', async () => {
+    let setWidthSpy = spyOn(component, 'setWidth');
+    component.ngAfterViewChecked();
+    expect(setWidthSpy).toHaveBeenCalled();
+  })
+
+});

--- a/src/app/variance-search/variance-list/variance-list.component.ts
+++ b/src/app/variance-search/variance-list/variance-list.component.ts
@@ -1,0 +1,162 @@
+import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, TemplateRef, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { LoadingService } from 'src/app/services/loading.service';
+import { DateTime } from 'luxon';
+import { Constants } from 'src/app/shared/utils/constants';
+import { DataService } from 'src/app/services/data.service';
+
+@Component({
+  selector: 'app-variance-list',
+  templateUrl: './variance-list.component.html',
+  styleUrls: ['./variance-list.component.scss']
+})
+export class VarianceListComponent implements AfterViewInit, AfterViewChecked {
+  public rowSchema: any[];
+  public subscriptions = new Subscription();
+  public loading = false;
+  public parks;
+  public variances: any[] = [];
+
+  @ViewChild('viewButton') viewButton: TemplateRef<any>;
+  @ViewChild('resolvedStatusTemplate') resolvedStatusTemplate: TemplateRef<any>;
+
+   constructor(
+    private cd: ChangeDetectorRef,
+    private loadingService: LoadingService,
+    private dataService: DataService,
+    private router: Router
+  ) {
+
+    this.subscriptions.add(
+      this.loadingService.getLoadingStatus().subscribe(status => {
+        if (status) {
+          // TODO: set this to 'status'
+          this.loading = false;
+        }
+      })
+    )
+    this.subscriptions.add(
+      this.dataService.watchItem(Constants.dataIds.VARIANCE_LIST).subscribe((res) => {
+        if (res) {
+          this.variances = res;
+          this.createTableRows(this.variances);
+        }
+      })
+    )
+    this.subscriptions.add(
+      this.dataService.watchItem(Constants.dataIds.ENTER_DATA_PARK).subscribe((res) => {
+        if (res) {
+          this.parks = res;
+        }
+      })
+    )
+  }
+
+  ngAfterViewInit() {
+    this.rowSchema = [
+      {
+        id: 'date', // column identifier
+        displayHeader: 'Date', // table header display name
+        dropdown: 0, // when does this column collapse into the dropdown? 0-never, 1-mobile, 2<xs, 3<sm, 4<md, 5<lg, 6<xl, 7-always
+        columnClasses: 'col', // additional column classes - for column sizing at different screen sizes
+        display: (row) => {
+          return this.formatDate(row.sk)
+        }, // returns what to display in the cell as a function of the row data
+        key: 'date' // value of pass object associated with column
+      },
+      {
+        id: 'park',
+        displayHeader: 'Park',
+        dropdown: 4,
+        columnClasses: 'col',
+        key: 'parkName'
+      },
+      {
+        id: 'subarea',
+        dropdown: 0,
+        columnClasses: 'col',
+        displayHeader: 'Subarea',
+        key: 'subAreaName'
+      },
+      {
+        id: 'activity',
+        dropdown: 3,
+        columnClasses: 'col',
+        displayHeader: 'Activity',
+        key: 'activity'
+      },
+      {
+        id: 'viewButton',
+        dropdown: 0,
+        columnClasses: 'col-1',
+        template: this.viewButton,
+        divider: true
+      }
+    ];
+    this.setWidth();
+    this.cd.detectChanges();
+  }
+
+  ngAfterViewChecked() {
+    this.setWidth();
+  }
+
+  createTableRows(varRecords) {
+    // populate metadata for variance records
+    // let subareas = this.dataService.getItemValue(Constants.dataIds.CURRENT_SUBAREA_LIST);
+    for (const record of varRecords) {
+      // get get subarea information
+      let subAreaId = record.pk.split('::')[1];
+      let activity = record.pk.split('::')[2];
+      record.subAreaId = subAreaId;
+      record.subAreaName = record.subAreaName;
+      record.date = record.sk;
+      record.activity = activity;
+    }
+  }
+
+  formatDate(date) {
+    let d = DateTime.fromFormat(date, 'yyyyMM');
+    return d.toFormat('MMMM yyyy');
+  }
+
+  formatActivityForUrl(activity) {
+    return activity.replace(/\s/g, '-').toLowerCase();
+  }
+
+  viewRecord(record) {
+    // TODO: find a better way to do this
+    let activityUrl = this.formatActivityForUrl(record.activity)
+    this.router.navigate([`/enter-data/${activityUrl}`], {
+      queryParams: {
+        date: record.date,
+        orcs: record.orcs,
+        subAreaId: record.subAreaId,
+        subAreaName: record.subAreaName,
+        parkName: record.parkName,
+      }
+    })
+  }
+
+  setWidth() {
+    let columns = [...this.rowSchema];
+    // don't forget about the cancel button column
+    columns.push({ id: 'resolvedStatusButton' });
+    // get groups of column ids
+    for (const col of columns) {
+      const columns = document.querySelectorAll<HTMLElement>(`#${col.id}`);
+      let maxWidth = 0;
+      for (let i = 0; i < columns.length; i++) {
+        maxWidth = Math.max(maxWidth, columns[i].scrollWidth);
+      }
+      for (let i = 0; i < columns.length; i++) {
+        if (columns[i].style.minWidth) {
+          columns[i].style.width = columns[i].style.minWidth + 'px';
+        } else {
+          columns[i].style.width = maxWidth + 'px';
+        }
+      }
+    }
+  }
+}

--- a/src/app/variance-search/variance-search.component.html
+++ b/src/app/variance-search/variance-search.component.html
@@ -1,0 +1,2 @@
+<app-variance-filters></app-variance-filters>
+<app-variance-list></app-variance-list>

--- a/src/app/variance-search/variance-search.component.spec.ts
+++ b/src/app/variance-search/variance-search.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VarianceSearchComponent } from './variance-search.component';
+
+describe('VarianceSearchComponent', () => {
+  let component: VarianceSearchComponent;
+  let fixture: ComponentFixture<VarianceSearchComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VarianceSearchComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VarianceSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/variance-search/variance-search.component.ts
+++ b/src/app/variance-search/variance-search.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-variance-search',
+  templateUrl: './variance-search.component.html',
+  styleUrls: ['./variance-search.component.scss']
+})
+export class VarianceSearchComponent {
+
+}

--- a/src/app/variance-search/variance-search.module.ts
+++ b/src/app/variance-search/variance-search.module.ts
@@ -1,0 +1,33 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VarianceSearchComponent } from './variance-search.component';
+import { VarianceFiltersComponent } from './variance-filters/variance-filters.component';
+import { TempComponent } from './temp/temp.component';
+import { TypeaheadModule } from '../shared/components/typeahead/typeahead.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
+import { PicklistModule } from '../shared/components/forms/picklist/picklist.module';
+import { VarianceListComponent } from './variance-list/variance-list.component';
+import { VarianceAccordionComponent } from './variance-list/variance-accordion/variance-accordion.component';
+
+@NgModule({
+  declarations: [
+    VarianceSearchComponent,
+    VarianceFiltersComponent,
+    TempComponent,
+    VarianceListComponent,
+    VarianceAccordionComponent,
+  ],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    TypeaheadModule,
+    CommonModule,
+    BsDatepickerModule,
+    PicklistModule
+  ],
+  exports: [
+    VarianceSearchComponent
+  ]
+})
+export class VarianceSearchModule { }

--- a/src/app/variance-search/variance-search.module.ts
+++ b/src/app/variance-search/variance-search.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { VarianceSearchComponent } from './variance-search.component';
 import { VarianceFiltersComponent } from './variance-filters/variance-filters.component';
-import { TempComponent } from './temp/temp.component';
 import { TypeaheadModule } from '../shared/components/typeahead/typeahead.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
@@ -14,7 +13,6 @@ import { VarianceAccordionComponent } from './variance-list/variance-accordion/v
   declarations: [
     VarianceSearchComponent,
     VarianceFiltersComponent,
-    TempComponent,
     VarianceListComponent,
     VarianceAccordionComponent,
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4807,6 +4807,11 @@ lru-cache@^9.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.1.1.tgz#c58a93de58630b688de39ad04ef02ef26f1902f1"
   integrity sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==
 
+luxon@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
+
 magic-string@0.29.0:
   version "0.29.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.29.0.tgz#f034f79f8c43dba4ae1730ffb5e8c4e084b16cf3"


### PR DESCRIPTION
### Jira Ticket:
BRS-898

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-898

### Description:
This ticket implements the barebones UI for variance checking and data review. 

The first iteration of the API requires that a `subarea` and `activity` are provided, so those fields are mandatory in the UI. The `park` field is mandatory as it is used to filter down the number of subareas shown in the subarea typeahead list. The `date` field is optional.

Upon fetching a list of variances based on the filters, the page is populated with accordions. By clicking on 'View', you can navigate directly to the record with the variance in question.