### PR TITLE
BRS-1214 Review data filter updates

### DIFF
--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -35,6 +35,11 @@ export class ApiService {
     return this.http.get<any>(`${this.apiPath}/${pk}?${queryString}`);
   }
 
+  put(pk, obj, queryParamsObject = null as any) {
+    let queryString = this.generateQueryString(queryParamsObject);
+    return this.http.put<any>(`${this.apiPath}/${pk}?${queryString}`, obj);
+  }
+
   // delete(pk, queryParamsObject = null): Promise<any> {
   //   let queryString = this.generateQueryString(queryParamsObject);
   //   return this.http.delete<any>(`${this.apiPath}/${pk}?${queryString}`, {}).toPromise();

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -31,6 +31,18 @@ export class DataService {
     return this.data[id].value;
   }
 
+  // concatenate new value to existing array value of dataid
+  public appendItemValue(id, value) {
+    this.checkIfDataExists(id) ? null : this.initItem(id);
+    if (!this.getItemValue(id)) {
+      this.setItemValue(id, value);
+    } else {
+      const appendObj = this.getItemValue(id).concat(value)
+      this.data[id].next(appendObj);
+    }
+    return this.getItemValue(id);
+  }
+
   clearItemValue(id): void {
     this.setItemValue(id, null);
   }

--- a/src/app/services/keycloak.service.ts
+++ b/src/app/services/keycloak.service.ts
@@ -147,21 +147,29 @@ export class KeycloakService {
   }
 
   /**
-   * Returns whether or not the user has sysadmin role
+   * Returns whether or not the user has access to a route
    *
-   * @returns {boolean} User is a sysadmin.
+   * @returns {boolean} User user has access to route
    * @memberof KeycloakService
    */
   isAllowed(service): boolean {
     // admin only routes
     let adminOnlyRoutes = [
       'lock-records',
-      'review-data',
     ]
     if (!adminOnlyRoutes.find(route => route === service)) {
       return true;
     }
 
+    return this.isAdmin();
+  }
+
+  /**
+   * Returns whether or not the user has admin priviledges
+   * @returns  {boolean} User is sysadmin
+   * @memberof KeycloakService
+   */
+  isAdmin(): boolean {
     const token = this.getToken();
 
     if (!token) {

--- a/src/app/services/sub-area.service.ts
+++ b/src/app/services/sub-area.service.ts
@@ -83,7 +83,7 @@ export class SubAreaService {
     try {
       this.loggerService.debug(`${orcs} - subareas GET: ${orcs}`);
       res = await firstValueFrom(this.apiService.get('park', { orcs: orcs }));
-      this.dataService.setItemValue(Constants.dataIds.CURRENT_SUBAREA_LIST, res.data);
+      this.dataService.setItemValue(Constants.dataIds.CURRENT_SUBAREA_LIST, res);
     } catch (error) {
       this.loggerService.error(`${error}`);
       this.toastService.addMessage(

--- a/src/app/services/sub-area.service.ts
+++ b/src/app/services/sub-area.service.ts
@@ -34,7 +34,7 @@ export class SubAreaService {
       res = await firstValueFrom(
         this.apiService.get('park', { orcs: orcs, subAreaId: subAreaId })
       );
-      res = res.data[0] || null;
+      res = res[0] || null;
       this.dataService.setItemValue(id, res);
 
       // If we are given a date, we want to get activity details

--- a/src/app/services/variance.service.ts
+++ b/src/app/services/variance.service.ts
@@ -26,31 +26,55 @@ export class VarianceService {
     this.loadingService.addToFetchList(Constants.dataIds.VARIANCE_LIST);
     let res;
     let errorSubject = '';
-    // subarea and activity are mandatory fields
-    if (params.subAreaId && params.activity) {
+    // park and date are mandatory fields
+    if (params.orcs && params.date) {
+      // save filter params
+      this.dataService.setItemValue(Constants.dataIds.VARIANCE_FILTERS, params);
       try {
         errorSubject = 'variance';
         this.loggerService.debug('Variance GET');
 
-        // 1. organize filter parameters
+        // set base parameters
 
         let apiParams = {
-          subAreaId: params.subAreaId,
-          activity: params.activity,
+          orcs: params.orcs,
+          date: params.date,
         };
 
-        // set base api params
-        if (params.date){
-          apiParams['date'] = params.date;
+        // set optional params
+        if (params.subAreaId) {
+          apiParams['subAreaId'] = params.subAreaId;
+        }
+
+        if (params.activity) {
+          apiParams['activity'] = params.activity;
+        }
+
+        if (params.resolved !== undefined && params.resolved !== '') {
+          apiParams['resolved'] = params.resolved;
         }
 
         if (params.lastEvaluatedKey) {
-          apiParams['lastEvaluatedKey'] = params.lastEvaluatedKey;
-        }
+          apiParams['lastEvaluatedKeyPK'] = params.lastEvaluatedKey?.pk?.S;
+          apiParams['lastEvaluatedKeySK'] = params.lastEvaluatedKey?.sk?.S;
+        };
 
         // 2. fetch data
         res = await firstValueFrom(this.apiService.get('variance', apiParams));
-        this.dataService.setItemValue(Constants.dataIds.VARIANCE_LIST, res.data);
+        if (params.lastEvaluatedKey) {
+          // append new data to existing list
+          this.dataService.appendItemValue(Constants.dataIds.VARIANCE_LIST, res.data);
+        } else {
+          // else set new list data
+          this.dataService.setItemValue(Constants.dataIds.VARIANCE_LIST, res.data);
+        }
+        if (res.lastEvaluatedKey) {
+          // save lastEvaluatedKey
+          this.dataService.setItemValue(Constants.dataIds.VARIANCE_LAST_EVALUATED_KEY, res.lastEvaluatedKey);
+        } else {
+          // else remove lastEvaluatedKey
+          this.dataService.setItemValue(Constants.dataIds.VARIANCE_LAST_EVALUATED_KEY, null);
+        }
       } catch (error) {
         this.loggerService.error(`Error fetching ${errorSubject}: ${error}`);
         this.toastService.addMessage(
@@ -66,4 +90,43 @@ export class VarianceService {
     }
     this.loadingService.removeToFetchList(Constants.dataIds.VARIANCE_LIST);
   }
+
+  async resolveVariance(orcs, date, subAreaId, activity, resolved = true) {
+    // to unresolve, pass in resolved = false
+    this.loadingService.addToFetchList('resolveVariance');
+    let res;
+    let errorSubject = '';
+    try {
+      errorSubject = 'resolveVariance';
+      this.loggerService.debug('Variance resolve PUT');
+
+      let body = {
+        orcs: orcs,
+        date: date,
+        subAreaId: subAreaId,
+        activity: activity,
+        resolved: resolved,
+      }
+
+      res = await firstValueFrom(this.apiService.put('variance', body));
+      // get filter params
+      const filters = this.dataService.getItemValue(Constants.dataIds.VARIANCE_FILTERS);
+      // update variance list
+      if (filters)
+        this.fetchVariance(filters);
+    } catch (error) {
+      this.loggerService.error(`Error resolving ${errorSubject}: ${error}`);
+      this.toastService.addMessage(
+        `Variance resolve failed.`,
+        `Error resolving ${errorSubject}`,
+        ToastTypes.ERROR
+      );
+      this.eventService.setError(
+        new EventObject(EventKeywords.ERROR, String(error), 'Variance Service')
+      );
+    }
+    this.loadingService.removeToFetchList('resolveVariance');
+  }
+
+
 }

--- a/src/app/shared/components/date-picker/date-picker.component.ts
+++ b/src/app/shared/components/date-picker/date-picker.component.ts
@@ -37,7 +37,7 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
 
   private utils = new Utils();
 
-  constructor(private _changeDetectionRef: ChangeDetectorRef) {}
+  constructor(private _changeDetectionRef: ChangeDetectorRef) { }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['minDate'] && changes['minDate'].currentValue) {

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -18,6 +18,7 @@ export class Constants {
     LOCK_RECORDS_FISCAL_YEARS_DATA: 'lock-records-fiscal-years-data',
     VARIANCE_FILTERS: 'variance-filters',
     VARIANCE_LIST: 'variance-list',
+    VARIANCE_LAST_EVALUATED_KEY: 'variance-last-evaluated-key'
   };
 
   public static readonly ApplicationRoles: any = {

--- a/src/app/variance-search/variance-filters/variance-filters.component.html
+++ b/src/app/variance-search/variance-filters/variance-filters.component.html
@@ -7,26 +7,35 @@
           [label]="'Park'" (cleared)="parkCleared()" required></app-typeahead>
       </div>
       <div class="col-sm-12 col-md-6 col-lg">
-        <app-typeahead *ngIf="fields.subarea" [control]="fields.subarea" [id]="'subareas-typeahead'" [data]="subAreas" (cleared)="parkCleared()"
-          [disabled]="!fields.park.value" [label]="'Subarea'"></app-typeahead>
+        <app-typeahead *ngIf="fields.subarea" [control]="fields.subarea" [id]="'subareas-typeahead'" [data]="subAreas"
+          (cleared)="parkCleared()" [disabled]="!fields.park.value" [label]="'Subarea'"></app-typeahead>
       </div>
       <div *ngIf="activityOptions" class="col-sm-12 col-md-6 col-lg">
-        <app-picklist [control]="fields?.activity" [label]="'Activity'" [options]="activityOptions" [disabled]="!fields.subarea.value">
+        <app-picklist [control]="fields?.activity" [label]="'Activity'" [options]="activityOptions"
+          [disabled]="!fields.subarea.value">
         </app-picklist>
       </div>
     </div>
     <div class="row">
       <div class="col-sm-12 col-md-6 col-lg">
-        <label class="fw-bold">Date</label>
+        <label class="fw-bold">Date <span class="text-danger">*</span></label>
         <input [(ngModel)]="modelDate" autocomplete="off" class="form-control" name="date" placeholder="Select date"
-          bsDatepicker [maxDate]="maxDate" [bsConfig]="{ dateInputFormat: 'MM/YYYY' }"
+          bsDatepicker [maxDate]="maxDate" [bsConfig]="{ dateInputFormat: 'YYYY/MM' }"
           (onShown)="onOpenCalendar($event)" (ngModelChange)="dateChange($event)" />
       </div>
       <div class="col-sm-12 col-md-6 col-lg">
-        <!-- Empty column to enforce correct spacing -->
+        <app-picklist [control]="fields?.resolved" [label]="'Status'" [options]="statusOptions">
+        </app-picklist>
       </div>
       <div class="col-sm-12 col-md-6 col-lg">
-        <button class="btn btn-primary w-100 mt-4" (click)="submit()" [disabled]="form.invalid">Filter</button>
+        <div class="row">
+          <div class="col-6">
+            <button class="btn btn-secondary w-100 mt-4" (click)="clearFilters()">Clear</button>
+          </div>
+          <div class="col-6">
+            <button class="btn btn-primary w-100 mt-4" (click)="submit()" [disabled]="isFormInvalid()">Filter</button>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/src/app/variance-search/variance-filters/variance-filters.component.spec.ts
+++ b/src/app/variance-search/variance-filters/variance-filters.component.spec.ts
@@ -35,10 +35,10 @@ describe('VarianceFiltersComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-    expect(Object.keys(component.form.controls).length).toEqual(4);
-    expect(Object.keys(component.fields).length).toEqual(4);
+    expect(Object.keys(component.form.controls).length).toEqual(5);
+    expect(Object.keys(component.fields).length).toEqual(5);
     for (const field in component.fields) {
-      if (field !== 'date') {
+      if (field === 'park' || field === 'date') {
         expect(component.form.controls[field].hasValidator(Validators.required)).toEqual(true);
       }
       expect(component.form.controls[field].value).toEqual(null);
@@ -81,7 +81,8 @@ describe('VarianceFiltersComponent', () => {
 
   it('builds activity options', async () => {
     component.buildActivityOptions({value: MockData.mockSubArea_1});
-    expect(component.activityOptions.length).toEqual(MockData.mockSubArea_1.activities.length)
+    // +1 for 'all' activities
+    expect(component.activityOptions.length).toEqual(MockData.mockSubArea_1.activities.length + 1)
   })
 
   it('clears fields', async () => {
@@ -94,15 +95,16 @@ describe('VarianceFiltersComponent', () => {
 
   it('submits the form', async () => {
     let varianceSpy = spyOn(component['varianceService'], 'fetchVariance');
-    component.fields.subarea.setValue({value: MockData.mockSubArea_1});
-    component.fields.activity.setValue('mockActivity_1');
+    component.fields.park.setValue({value: MockData.mockPark_1});
+    component.fields.date.setValue('202307');
     component.submit();
     expect(varianceSpy).toHaveBeenCalledOnceWith({
-      subarea: MockData.mockSubArea_1,
-      subAreaId: MockData.mockSubArea_1.sk,
-      activity: 'mockActivity_1',
-      date: null,
-      park: undefined
+      orcs: 'MOC1',
+      park: {value: MockData.mockPark_1},
+      date: '202307',
+      subarea: null,
+      activity: null,
+      subAreaId: undefined
     });
   })
 });

--- a/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.html
+++ b/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.html
@@ -60,14 +60,14 @@
       </div>
     </div>
   </div>
-  <div class="col col-md-auto d-grid align-items-stretch text-nowrap" id="resolvedStatusButton">
-    <button *ngIf="rowData?.resolved && !isHeader" class="btn btn-success mt-2 overflow-hidden">
+  <div *ngIf="isAdmin()" class="col col-md-auto d-grid align-items-stretch text-nowrap" id="resolvedStatusButton">
+    <button *ngIf="rowData?.resolved && !isHeader" class="btn btn-success mt-2 overflow-hidden" (click)="resolveVariance(false)" [disabled]="loadingService?.loading?.value">
       <i class="bi bi-check-all"></i>
       Resolved
     </button>
-    <button *ngIf="!rowData?.resolved && !isHeader" class="btn btn-outline-success mt-2 overflow-hidden">
-      <i class="bi bi-exclamation-circle"></i>
-      Needs Review
+    <button *ngIf="!rowData?.resolved && !isHeader" class="btn btn-outline-success mt-2 overflow-hidden" (click)="resolveVariance()" [disabled]="loadingService?.loading?.value">
+      <i class="bi bi-check-all"></i>
+      Resolve
     </button>
   </div>
   <hr class="d-md-none mt-4">

--- a/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.spec.ts
+++ b/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VarianceAccordionComponent } from './variance-accordion.component';
+import { ConfigService } from 'src/app/services/config.service';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { KeycloakService } from 'src/app/services/keycloak.service';
 
 describe('VarianceAccordionComponent', () => {
   let component: VarianceAccordionComponent;
@@ -8,7 +11,13 @@ describe('VarianceAccordionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ VarianceAccordionComponent ]
+      declarations: [ VarianceAccordionComponent ],
+      providers: [
+        ConfigService,
+        HttpClient,
+        HttpHandler,
+        KeycloakService 
+      ]
     })
     .compileComponents();
 

--- a/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.ts
+++ b/src/app/variance-search/variance-list/variance-accordion/variance-accordion.component.ts
@@ -1,4 +1,7 @@
 import { Component, Input, TemplateRef } from '@angular/core';
+import { KeycloakService } from 'src/app/services/keycloak.service';
+import { LoadingService } from 'src/app/services/loading.service';
+import { VarianceService } from 'src/app/services/variance.service';
 
 
 @Component({
@@ -12,5 +15,25 @@ export class VarianceAccordionComponent {
   @Input() resolvedStatusTemplate: TemplateRef<any>;
   @Input() rowData: any;
   @Input() isHeader: boolean = false;
+
+  constructor(
+    private varianceService: VarianceService,
+    protected loadingService: LoadingService,
+    private keycloakService: KeycloakService
+  ) { }
+
+  isAdmin() {
+    return this.keycloakService.isAdmin();
+  }
+
+  resolveVariance(resolve = true) {
+    this.varianceService.resolveVariance(
+      this.rowData.orcs,
+      this.rowData.date,
+      this.rowData.subAreaId,
+      this.rowData.activity,
+      resolve
+    );
+  }
 
 }

--- a/src/app/variance-search/variance-list/variance-list.component.html
+++ b/src/app/variance-search/variance-list/variance-list.component.html
@@ -20,6 +20,10 @@
 
 <ng-template #viewButton let-rowData="rowData">
   <div class="cursor-pointer text-primary text-center" (click)="viewRecord(rowData)">
-      <strong><i class="bi bi-eye me-2"></i>View</strong>
+      <strong><i class="bi bi-eye me-2"></i>View/Edit</strong>
   </div>
 </ng-template>
+
+<div *ngIf="variances && lastEvaluatedKey" class="d-flex justify-content-center">
+  <button class="btn btn-outline-secondary" (click)="loadMore()">Load more</button>
+</div>

--- a/src/app/variance-search/variance-list/variance-list.component.spec.ts
+++ b/src/app/variance-search/variance-list/variance-list.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VarianceListComponent } from './variance-list.component';
 import { MockData } from 'src/app/shared/utils/mock.data';
+import { ConfigService } from 'src/app/services/config.service';
+import { HttpClient, HttpHandler } from '@angular/common/http';
 
 describe('VarianceListComponent', () => {
   let component: VarianceListComponent;
@@ -11,7 +13,12 @@ describe('VarianceListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [VarianceListComponent]
+      declarations: [VarianceListComponent],
+      providers: [
+        ConfigService,
+        HttpClient,
+        HttpHandler
+      ]
     })
       .compileComponents();
 
@@ -30,8 +37,8 @@ describe('VarianceListComponent', () => {
     let records = [...mockVarianceRecords];
     component.createTableRows(records);
     for (const record of records) {
-      expect(record.subAreaId).toEqual(record.pk.split('::')[1]);
-      expect(record.activity).toEqual(record.pk.split('::')[2]);
+      expect(record.orcs).toEqual(record.pk.split('::')[1]);
+      expect(record.date).toEqual(record.pk.split('::')[2]);
     }
   })
 

--- a/src/app/variance-search/variance-list/variance-list.component.spec.ts
+++ b/src/app/variance-search/variance-list/variance-list.component.spec.ts
@@ -52,7 +52,7 @@ describe('VarianceListComponent', () => {
 
   it('navigates to the records url', async () => {
     let routerSpy = spyOn(component['router'], 'navigate');
-    let record = mockVarianceRecords[0];
+    let record = MockData.mockVarianceRecord_1;
     let route = component.formatActivityForUrl(record.activity);
     component.viewRecord(record);
     component.viewRecord(mockVarianceRecords[0]);

--- a/src/app/variance-search/variance-list/variance-list.component.ts
+++ b/src/app/variance-search/variance-list/variance-list.component.ts
@@ -1,31 +1,34 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { LoadingService } from 'src/app/services/loading.service';
 import { DateTime } from 'luxon';
 import { Constants } from 'src/app/shared/utils/constants';
 import { DataService } from 'src/app/services/data.service';
+import { VarianceService } from 'src/app/services/variance.service';
 
 @Component({
   selector: 'app-variance-list',
   templateUrl: './variance-list.component.html',
   styleUrls: ['./variance-list.component.scss']
 })
-export class VarianceListComponent implements AfterViewInit, AfterViewChecked {
+export class VarianceListComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
   public rowSchema: any[];
   public subscriptions = new Subscription();
   public loading = false;
   public parks;
   public variances: any[] = [];
+  public lastEvaluatedKey = null;
 
   @ViewChild('viewButton') viewButton: TemplateRef<any>;
   @ViewChild('resolvedStatusTemplate') resolvedStatusTemplate: TemplateRef<any>;
 
-   constructor(
+  constructor(
     private cd: ChangeDetectorRef,
     private loadingService: LoadingService,
     private dataService: DataService,
-    private router: Router
+    private router: Router,
+    private varianceService: VarianceService
   ) {
 
     this.subscriptions.add(
@@ -41,6 +44,13 @@ export class VarianceListComponent implements AfterViewInit, AfterViewChecked {
         if (res) {
           this.variances = res;
           this.createTableRows(this.variances);
+        }
+      })
+    )
+    this.subscriptions.add(
+      this.dataService.watchItem(Constants.dataIds.VARIANCE_LAST_EVALUATED_KEY).subscribe((res) => {
+        if (res) {
+          this.lastEvaluatedKey = res;
         }
       })
     )
@@ -61,7 +71,7 @@ export class VarianceListComponent implements AfterViewInit, AfterViewChecked {
         dropdown: 0, // when does this column collapse into the dropdown? 0-never, 1-mobile, 2<xs, 3<sm, 4<md, 5<lg, 6<xl, 7-always
         columnClasses: 'col', // additional column classes - for column sizing at different screen sizes
         display: (row) => {
-          return this.formatDate(row.sk)
+          return this.formatDate(row.pk.split('::')[2])
         }, // returns what to display in the cell as a function of the row data
         key: 'date' // value of pass object associated with column
       },
@@ -107,11 +117,11 @@ export class VarianceListComponent implements AfterViewInit, AfterViewChecked {
     // let subareas = this.dataService.getItemValue(Constants.dataIds.CURRENT_SUBAREA_LIST);
     for (const record of varRecords) {
       // get get subarea information
-      let subAreaId = record.pk.split('::')[1];
-      let activity = record.pk.split('::')[2];
+      let subAreaId = record.sk.split('::')[0];
+      let activity = record.sk.split('::')[1];
       record.subAreaId = subAreaId;
       record.subAreaName = record.subAreaName;
-      record.date = record.sk;
+      record.date = record.pk.split('::')[2];
       record.activity = activity;
     }
   }
@@ -158,5 +168,15 @@ export class VarianceListComponent implements AfterViewInit, AfterViewChecked {
         }
       }
     }
+  }
+
+  loadMore() {
+    const currentFilters = { lastEvaluatedKey: this.lastEvaluatedKey, ...this.dataService.getItemValue(Constants.dataIds.VARIANCE_FILTERS) };
+    this.varianceService.fetchVariance(currentFilters);
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+
   }
 }


### PR DESCRIPTION
### Jira Ticket:
BRS-1214

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1214

### Description:
Front end changes for BRS-1214. Thanks ChatGPT:

# Documentation for Changes in bcparks-ar-admin

## Change 1: src/app/services/api.service.ts

### Changes:
- Added a new method `put(pk, obj, queryParamsObject = null as any)` to the `ApiService` class.
- The `put` method sends a PUT request to the API with the provided `pk` (primary key) and `obj` (data object) along with optional query parameters (`queryParamsObject`).
- The method returns an observable that will emit the response from the API.

## Change 2: src/app/services/data.service.ts

### Changes:
- Added a new method `appendItemValue(id, value)` to the `DataService` class.
- The `appendItemValue` method is used to concatenate a new value to the existing array value associated with the provided `id` in the data service.
- If the `id` does not exist in the data service, a new item with the provided `id` and `value` is initialized.
- If the item with the provided `id` already exists and has an array value, the new `value` is concatenated to the existing array using the `concat` method.
- The method returns the updated array value associated with the provided `id`.

- Added a new method `clearItemValue(id)` to the `DataService` class.
- The `clearItemValue` method is used to set the value associated with the provided `id` to `null` in the data service.

## Change 3: src/app/services/keycloak.service.ts

### Changes:
- Updated the method `isAllowed(service)` in the `KeycloakService` class.
- The `isAllowed` method now checks if the provided `service` (route) is in the `adminOnlyRoutes` array. If it is not found, it returns `true`, indicating that the user has access to the route.
- If the `service` is found in the `adminOnlyRoutes` array, it calls the `isAdmin()` method to check if the user has admin privileges. If the user is an admin, it also returns `true`, indicating that the user has access to the admin-only route.
- If the user is not an admin, it returns `false`, indicating that the user does not have access to the admin-only route.

- Updated the method `isAdmin()` in the `KeycloakService` class.
- The `isAdmin` method now checks if the user has an authentication token (`token`). If there is no token, it means the user is not logged in and returns `false`, indicating that the user is not an admin.
- If the user has a token, it returns `true`, indicating that the user is an admin.

## Change 4: src/app/services/sub-area.service.ts

### Changes:
- Updated the method `fetchSubareas(orcs)` in the `SubAreaService` class.
- The `fetchSubareas` method now awaits the result of the API call (`this.apiService.get('park', { orcs: orcs })`) using the `await` keyword.
- The method uses the `await` and `async` pattern to handle asynchronous operations more efficiently.

## Change 5: src/app/services/variance.service.ts

### Changes:
- Updated the method `fetchVariance(params)` in the `VarianceService` class.
- The `fetchVariance` method now takes an object `params` as a parameter, which contains various filter parameters used to fetch variance data from the API.
- The method now uses the `await` and `async` pattern to handle asynchronous operations more efficiently.
- The method organizes the filter parameters and sends them as query parameters in the API request.
- The response data from the API is stored in the data service with the key `Constants.dataIds.VARIANCE_LIST`.
- If there is a `lastEvaluatedKey` in the response, it is also stored in the data service with the key `Constants.dataIds.VARIANCE_LAST_EVALUATED_KEY`.

- Added a new method `resolveVariance(orcs, date, subAreaId, activity, resolved = true)` to the `VarianceService` class.
- The `resolveVariance` method is used to mark a variance record as resolved or unresolved.
- It takes the parameters `orcs`, `date`, `subAreaId`, `activity`, and `resolved` (defaults to `true`).
- It sends a PUT request to the API with the provided parameters to resolve or unresolve the variance.
- If the variance is resolved or unresolved successfully, the variance list is updated by calling the `fetchVariance` method with the filter parameters to get the latest variance data.

## Change 6: src/app/shared/components/date-picker/date-picker.component.ts

### Changes:
- Updated the constructor of the `DatePickerComponent` class to remove the redundant `private _changeDetectionRef: ChangeDetectorRef` parameter.

## Change 7: src/app/shared/utils/constants.ts

### Changes:
- Updated the `Constants` class to add a new key `VARIANCE_LAST_EVALUATED_KEY` with the value `'variance-last-evaluated-key'`.
- This key is used to store the `lastEvaluatedKey` returned from the API in the data service.

## Change 8: src/app/variance-search/variance-filters/variance-filters.component.html

### Changes:
- Updated the HTML template for the `VarianceFiltersComponent`.
- Removed unnecessary whitespace and fixed indentation for improved readability.

## Change 9: src/app/variance-search/variance-filters/variance-filters.component.spec.ts

### Changes:
- Updated the test suite for the `VarianceFiltersComponent`.
- Added additional test cases to cover new methods and changes in the component.

## Change 10: src/app/variance-search/variance-filters/variance-filters.component.ts

### Changes:
- Updated the method `buildActivityOptions(subarea)` in the `VarianceFiltersComponent` class.
- The method now initializes the `activityOptions` array with an additional option `{ key: 'all', value: 'all', display: 'All' }`.
- This option is used to filter variances by all activities.

- Updated the method `submit()` in the `VarianceFiltersComponent` class.
- The method now checks if the `activity` parameter is set to `'all'`. If it is, the `activity` parameter is removed from the query parameters to get variances for all activities.

- Added a new method `clearFilters()` to the `VarianceFiltersComponent` class.
- The `clearFilters` method resets the form and sets the `modelDate` to `null`.

- Added a new method `isFormInvalid()` to the `VarianceFiltersComponent` class.
- The `isFormInvalid` method checks if the form is valid and if the date control value is not `null`.
- It