### PR TITLE
BRS-250: Remove historical badge from legacy parks

### DIFF
--- a/src/app/enter-data/sub-area-search/sub-area-search.component.ts
+++ b/src/app/enter-data/sub-area-search/sub-area-search.component.ts
@@ -129,10 +129,14 @@ export class SubAreaSearchComponent implements OnDestroy, AfterViewInit {
     }
     this.loadingUI = false;
   }
-
+  //If the item has an ORC it is a park. 
+  //Skiping parks to remove historical bubble from frontend. 
   formatLegacyTypeaheadLabel(list) {
     for (const item of list) {
       if (item.value.isLegacy) {
+        if(item.value.orcs){
+          continue
+        }
         item.template = this.legacyTypeAheadTemplate;
       }
     }

--- a/src/app/enter-data/sub-area-search/sub-area-search.component.ts
+++ b/src/app/enter-data/sub-area-search/sub-area-search.component.ts
@@ -134,8 +134,8 @@ export class SubAreaSearchComponent implements OnDestroy, AfterViewInit {
   formatLegacyTypeaheadLabel(list) {
     for (const item of list) {
       if (item.value.isLegacy) {
-        if(item.value.orcs){
-          continue
+        if (item.value.orcs) {
+          continue;
         }
         item.template = this.legacyTypeAheadTemplate;
       }


### PR DESCRIPTION
### Jira Ticket:
[BRS-250](https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=36685732)
### Jira Ticket URL:
[https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=36685732](https://bcparksdigital.atlassian.net/browse/BRS-123)

### Description:
Removed the historical "Bubble" from isLegacy parks on the front end. 
The other part of this ticket was about adding new subareas to parks with the isLegacy parameter. I was able to do this in the DEV environment with no changes to the api. 