### PR TITLE
PDR-255-5 reset variance tooltip on form discard

### DIFF
--- a/src/app/forms/root-form/root-form.component.ts
+++ b/src/app/forms/root-form/root-form.component.ts
@@ -49,6 +49,8 @@ export class RootFormComponent implements OnInit, OnDestroy {
         this.loading = res;
       })
     );
+    // Clear variance fields before subscribing.
+    this.dataService.setItemValue(Constants.dataIds.VARIANCE_WARNING_TRIGGERED_FIELDS, null);
     this.subscriptions.add(
       this.dataService.watchItem(Constants.dataIds.VARIANCE_WARNING_TRIGGERED_FIELDS).subscribe((res) => {
         this.varianceData = res;


### PR DESCRIPTION
Patch for https://github.com/bcgov/bcparks-ar-admin/issues/255.

Discarding a form after triggering a variance persists the variance tooltips between other records of the same activity type. With this fix, the triggered variance fields are cleared on navigation to the page so the call starts fresh.