### PR TITLE
BRS-368: Show Gross Camping Revenue on Historic Records after Migration

### DIFF
--- a/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/backcountry-camping-accordion/backcountry-camping-accordion.component.ts
@@ -57,17 +57,32 @@ export class BackcountryCampingAccordionComponent implements OnDestroy {
   }
 
   buildAccordion() {
-    // legacy data is vastly different
+    // BRS-368: business logic to show grossCampingRevenue after migration.
+    // Some records will be legacy and be vastly different, but some will have
+    // both attribute data - keep `if` logic to differentiate in the future.
     if (this.data?.isLegacy) {
-      this.summaries = [{
-        attendanceItems: [
-          {
-            itemName: 'People',
-            value: this.data?.people,
-            variance: this.variance?.value?.hasOwnProperty('people')
-          }
-        ]
-      }]
+      this.summaries = [
+        {
+          attendanceItems: [
+            {
+              itemName: 'People',
+              value: this.data?.people,
+              variance: this.variance?.value?.hasOwnProperty('people')
+            }
+          ],
+          revenueLabel: 'Net revenue',
+          revenueItems: [
+            {
+              itemName: 'Gross camping revenue',
+              value: this.data?.grossCampingRevenue,
+              variance: this.variance?.value?.hasOwnProperty('grossCampingRevenue')
+            },
+          ],
+          revenueTotal: this.formulaService.basicNetRevenue([
+            this.data?.grossCampingRevenue,
+          ]),
+        },
+      ];
     } else {
       this.summaries = [
         {


### PR DESCRIPTION
### Ticket:
BRS-368

### Ticket URL:
[BRS-368](https://github.com/bcgov/bcparks-ar-admin/issues/368)

### Description:
- Backcountry Camping records will now show `grossCampingRevenue` data on frontend for isLegacy records
- Corresponds to the migration to move several subareas into one subarea (Marine Sites) and make the old subareas "historic" in the admin.

