### PR TITLE
BRS-389 - Implement Winter Camping Data Fields

### DIFF
--- a/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.spec.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.spec.ts
@@ -36,13 +36,13 @@ describe('FrontcountryCampingAccordionComponent', () => {
   it('builds accordion', async () => {
     component.data = MockData.mockFrontcountryCampingRecord_1;
     component.buildAccordion();
-    expect(component.summaries.length).toEqual(3);
+    expect(component.summaries.length).toEqual(4);
   });
 
   it('builds legacy accordion', async () => {
     component.data = MockData.mockFrontcountryCampingRecord_Legacy;
     component.buildAccordion();
-    expect(component.summaries.length).toEqual(5);
+    expect(component.summaries.length).toEqual(6);
   });
 
   it('unsubscribes on destroy', async () => {

--- a/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.ts
+++ b/src/app/enter-data/accordion-manager/frontcountry-camping-accordion/frontcountry-camping-accordion.component.ts
@@ -61,6 +61,25 @@ export class FrontcountryCampingAccordionComponent implements OnDestroy {
       {
         isLegacy: this.data?.isLegacy || false,
         title: 'Camping party nights',
+        subtitle: 'Winter Rate',
+        attendanceLabel: 'Total attendance (people)',
+        attendanceItems: [
+
+          {
+            itemName: 'Winter rate standard',
+            value: this.data?.winterCampingPartyNightsAttendanceStandard,
+            variance: this.variance?.value?.hasOwnProperty('winterCampingPartyNightsAttendanceStandard')
+          },
+          {
+            itemName: 'Winter rate social services fee exemption',
+            value: this.data?.winterCampingPartyNightsAttendanceSocial,
+            variance: this.variance?.value?.hasOwnProperty('winterCampingPartyNightsAttendanceSocial')
+          },
+        ]
+      },
+      {
+        isLegacy: this.data?.isLegacy || false,
+        subtitle: 'Standard',
         attendanceLabel: 'Total attendance (people)',
         attendanceItems: [
           {
@@ -92,6 +111,8 @@ export class FrontcountryCampingAccordionComponent implements OnDestroy {
               this.formulaService.formatLegacyAttendance(this.data?.legacyData?.legacy_frontcountryCampingTotalCampingParties).result :
               this.formulaService.frontcountryCampingPartyNightsAttendance(
                 [
+                  this.data?.winterCampingPartyNightsAttendanceStandard,
+                  this.data?.winterCampingPartyNightsAttendanceSocial,
                   this.data?.campingPartyNightsAttendanceStandard,
                   this.data?.campingPartyNightsAttendanceSenior,
                   this.data?.campingPartyNightsAttendanceSocial,
@@ -108,6 +129,8 @@ export class FrontcountryCampingAccordionComponent implements OnDestroy {
           this.formulaService.formatLegacyFrontcountryCampingTotalAttendance(this.data?.legacyData?.legacy_frontcountryCampingTotalCampingParties) :
           this.formulaService.frontcountryCampingPartyAttendance(
             [
+              this.data?.winterCampingPartyNightsAttendanceStandard,
+              this.data?.winterCampingPartyNightsAttendanceSocial,
               this.data?.campingPartyNightsAttendanceStandard,
               this.data?.campingPartyNightsAttendanceSenior,
               this.data?.campingPartyNightsAttendanceSocial,

--- a/src/app/forms/frontcountry-camping/frontcountry-camping.component.html
+++ b/src/app/forms/frontcountry-camping/frontcountry-camping.component.html
@@ -13,6 +13,54 @@
     <!-- Camping party nights -->
     <h2>Camping party nights</h2>
     <div class="row">
+      <!-- Winter -->
+      <div class="col-12 d-flex flex-column">
+        <div class="row">
+          <!-- Winter Toggle-->
+          <div class="row">
+            <div class="col-12 col-lg-6 m-3 form-check form-switch align-items-end">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                [checked]="winter"
+                (change)="onWinterToggle()"
+                name="winterCheckbox"
+              />
+              <div *ngIf="winter">Winter</div>
+              <div *ngIf="!winter" class="text-muted">Winter</div>
+            </div>
+          </div>
+          <!-- Winter Standard -->
+          <div *ngIf="winter" class="row">
+            <div class="input-box mb-2 d-flex align-items-end"
+              [popover]="getPopoverData('winterCampingPartyNightsAttendanceStandard') ? popover : null"
+              [popoverContext]="{variance: getPopoverData('winterCampingPartyNightsAttendanceStandard')}" placement="bottom"
+              triggers="mouseenter:mouseleave">
+              <ngds-number-input [control]="form?.controls?.['winterCampingPartyNightsAttendanceStandard']" [decimalPlaces]="0"
+                [justify]="'end'" [invalidConfig]="invalidConfig" [allowNegative]="false" [label]="'Winter rate standard'"
+                [placeholder]="'No data'" [loadWhile]="loading">
+                <i ngdsInputPrepend class="bi bi-person-fill px-2"></i>
+              </ngds-number-input>
+            </div>
+            <!-- Winter Social -->
+            <div class="input-box mb-2 d-flex align-items-end"
+              [popover]="getPopoverData('winterCampingPartyNightsAttendanceSocial') ? popover : null"
+              [popoverContext]="{variance: getPopoverData('winterCampingPartyNightsAttendanceSocial')}" placement="bottom"
+              triggers="mouseenter:mouseleave">
+              <ngds-number-input [control]="form?.controls?.['winterCampingPartyNightsAttendanceSocial']" [decimalPlaces]="0"
+                [justify]="'end'" [invalidConfig]="invalidConfig" [allowNegative]="false"
+                [label]="'Winter rate social services fee exemption'" [placeholder]="'No data'" [loadWhile]="loading">
+                <i ngdsInputPrepend class="bi bi-person-fill px-2"></i>
+              </ngds-number-input>
+            </div>
+            <div class="row">
+              <!-- Attendance info -->
+              <app-info-text class="text-block"
+                [text]="'Walk-in and Unable to Collect should be added to Standard.'"></app-info-text>
+            </div>
+          </div>
+        </div>
+      </div>
       <!-- Attendance -->
       <div class="col-12 col-lg-6 d-flex flex-column">
         <div class="row">
@@ -53,7 +101,7 @@
         <div class="row">
           <!-- Attendance info -->
           <app-info-text class="text-block"
-            [text]="'Winter, Walk-in, and Unable to Collect should be added to Standard.'"></app-info-text>
+            [text]="'Walk-in and Unable to Collect should be added to Standard.'"></app-info-text>
         </div>
         <div class="row">
           <!-- Long stay -->

--- a/src/app/services/formula.service.ts
+++ b/src/app/services/formula.service.ts
@@ -168,7 +168,7 @@ export class FormulaService {
     attendances: any[],
     modifier?: number
   ): formulaResult {
-    let formula = `Total attendance = (Standard + Senior + SSCFE + Long stay)`;
+    let formula = `Total attendance = (Winter Standard + Winter SSCFE + Standard + Senior + SSCFE + Long stay)`;
     if (modifier) {
       formula += ` x ${modifier}`;
     }

--- a/src/app/services/winter-toggle.service.spec.ts
+++ b/src/app/services/winter-toggle.service.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { WinterToggleService } from './winter-toggle.service';
+
+describe('WinterToggleService', () => {
+  let service: WinterToggleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [WinterToggleService]
+    });
+    service = TestBed.inject(WinterToggleService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialize with false value', (done: DoneFn) => {
+    service.getWinterToggle.subscribe((value: boolean) => {
+      expect(value).toBeFalse();
+      done();
+    });
+  });
+
+  it('should update value when setWinterToggle is called', (done: DoneFn) => {
+    const newValue = true;
+
+    service.setWinterToggle(newValue);
+
+    service.getWinterToggle.subscribe((value: boolean) => {
+      expect(value).toBeTrue();
+      done();
+    });
+  });
+});

--- a/src/app/services/winter-toggle.service.ts
+++ b/src/app/services/winter-toggle.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WinterToggleService {
+  private winter = new BehaviorSubject(false);
+
+  get getWinterToggle() {
+    return this.winter.asObservable();
+  }
+
+  setWinterToggle(value: boolean) {
+    this.winter.next(value);
+  }
+}

--- a/src/app/shared/components/accordion/summary-section/summary-section.component.html
+++ b/src/app/shared/components/accordion/summary-section/summary-section.component.html
@@ -1,5 +1,6 @@
 <div>
   <h3 *ngIf="section?.title">{{ section?.title }}</h3>
+  <h4 *ngIf="section?.subtitle" class="mt-4">{{ section?.subtitle }}</h4>
   <div
     class="mb-3"
     *ngIf="section.attendanceItems"

--- a/src/app/shared/components/accordion/summary-section/summary-section.component.ts
+++ b/src/app/shared/components/accordion/summary-section/summary-section.component.ts
@@ -12,6 +12,7 @@ export interface summaryLineItem {
 
 export interface summarySection {
   title?: string;
+  subtitle?: string;
   isLegacy?: boolean;
   attendanceLabel?: string;
   attendanceTotal?: formulaResult;

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -93,6 +93,8 @@ export class Constants {
       revenueGrossCamping: 0.2,
     },
     frontCountryCamping: {
+      winterCampingPartyNightsAttendanceStandard: 0.2,
+      winterCampingPartyNightsAttendanceSocial: 0.2,
       campingPartyNightsAttendanceStandard: 0.2,
       campingPartyNightsAttendanceSenior: 0.2,
       campingPartyNightsAttendanceSocial: 0.2,

--- a/src/app/shared/utils/mock.data.ts
+++ b/src/app/shared/utils/mock.data.ts
@@ -286,6 +286,8 @@ export class MockData {
     orcs: 'MOC1',
     lastUpdated: '2023-01-01T00:00:00.000Z',
     isLocked: false,
+    winterCampingPartyNightsAttendanceStandard: 1,
+    winterCampingPartyNightsAttendanceSocial: 1,
     campingPartyNightsAttendanceStandard: 1,
     campingPartyNightsAttendanceSenior: 1,
     campingPartyNightsAttendanceSocial: 1,


### PR DESCRIPTION
### Ticket:
BRS-389

### Ticket URL:
#389 

### Description:
- A toggle-able`Winter` button will show `Winter standard` and `Winter SSCFE` in the Frontcountry Camping fields
- Winter toggle button persists through user session as a service
- Winter camping fields included in attendance calculation and export fields
- Tweak to the summary section on Enter Data to show winter camping fields with appropriate headings
