### PR TITLE
AR-427-5 removing invalid field display to prevent dropdown graphics bug

### DIFF
--- a/src/app/manage-subareas/subarea-form/subarea-form.component.html
+++ b/src/app/manage-subareas/subarea-form/subarea-form.component.html
@@ -5,7 +5,7 @@
       [label]="'ORCS'"
       [selectionListItems]="_parks?.value"
       [resetButton]="true"
-      [hideInvalidState]="!submitted"
+      [hideInvalidState]="true"
       [disabled]="editMode"
     >
     </ngds-typeahead-input>
@@ -17,7 +17,7 @@
       [selectionListItems]="_parkNames?.value"
       [disabled]="editMode"
       [resetButton]="true"
-      [hideInvalidState]="!submitted"
+      [hideInvalidState]="true"
     >
     </ngds-typeahead-input>
   </div>
@@ -30,7 +30,7 @@
     [resetButton]="true"
     [hideInvalidState]="true"
     [selectionListItems]="_regions.value"
-    [hideInvalidState]="!submitted"
+    [hideInvalidState]="true"
   >
   </ngds-typeahead-input>
 </div>
@@ -42,7 +42,7 @@
     [hideInvalidState]="true"
     [selectionListItems]="_sections.value"
     [disabled]="!form?.controls?.['region']?.value"
-    [hideInvalidState]="!submitted"
+    [hideInvalidState]="true"
   >
   </ngds-typeahead-input>
 </div>
@@ -54,7 +54,7 @@
     [hideInvalidState]="true"
     [selectionListItems]="_managementAreas.value"
     [disabled]="!form?.controls?.['section']?.value"
-    [hideInvalidState]="!submitted"
+    [hideInvalidState]="true"
   >
   </ngds-typeahead-input>
 </div>
@@ -65,7 +65,7 @@
     [resetButton]="true"
     [hideInvalidState]="true"
     [selectionListItems]="_bundles.value"
-    [hideInvalidState]="!submitted"
+    [hideInvalidState]="true"
   >
   </ngds-typeahead-input>
 </div>
@@ -75,7 +75,7 @@
     [control]="form?.controls?.['subAreaName']"
     [label]="'Subarea name'"
     [resetButton]="true"
-    [hideInvalidState]="!submitted"
+    [hideInvalidState]="true"
   >
   </ngds-text-input>
 </div>
@@ -87,7 +87,7 @@
     [selectionListItems]="activities"
     [resetButton]="true"
     [placeholder]="'Please select'"
-    [hideInvalidState]="!submitted"
+    [hideInvalidState]="true"
   >
   </ngds-typeahead-input>
 </div>
@@ -104,7 +104,7 @@
     type="button"
     class="btn btn-primary"
     (click)="onSubmit()"
-    [disabled]="!form?.dirty"
+    [disabled]="!form?.valid"
   >
     Submit
   </button>

--- a/src/app/manage-subareas/subarea-form/subarea-form.component.ts
+++ b/src/app/manage-subareas/subarea-form/subarea-form.component.ts
@@ -64,7 +64,7 @@ export class SubareaFormComponent implements OnInit, OnDestroy {
     section: new UntypedFormControl(null, [Validators.required]),
     managementArea: new UntypedFormControl(null, [Validators.required]),
     bundle: new UntypedFormControl(null, [Validators.required]),
-    activities: new UntypedFormControl(null, [this.selectAtLeastOneValidator()]),
+    activities: new UntypedFormControl(null, [Validators.required, this.selectAtLeastOneValidator()]),
   });
 
   public _parks = new BehaviorSubject(null);


### PR DESCRIPTION
As described in #427 comments, there is a graphical bug that occurs in the dropdown menus when the invalid state is triggered. The dropdown menu appears behind other menu entry fields (particularly text entry boxes). 

This is a bug with the NGDS-Toolkit form engine and has been captured here: https://github.com/digitalspace/ngds-toolkit/issues/24.

A temporary workaround is simply not displaying the invalid state of the fields. The validity is still enforced (you cannot proceed until the whole form is valid), however, the red invalid state with invalid reason will no longer be displayed (was not in the designs anyways).