### PR TITLE
BRS-492: Add land acknowledgment to footer

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,3 +1,8 @@
+
+<div class="land-acknowledgement">
+  <p>We acknowledge all First Nations on whose territories BC Parks were established. <br> We honour their connection to the land and respect the importance of their diverse teachings, traditions, and practices within these territories.</p>
+</div>
+ 
 <footer class="text-center text-white" id="footer">
   <nav>
     <div class="row">

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -1,9 +1,25 @@
 @import "/src/assets/themes/variables";
 
+.land-acknowledgement {
+  background: #2464A4; 
+  color: white; 
+  text-align: center; 
+  width: 100vw; 
+  margin: 0; 
+  padding: 1.2rem 0; 
+  position: relative; 
+  border-top: $bcgold 0.1rem solid; 
+}
+.land-acknowledgement p {
+  margin: 0; 
+  padding: .5rem 0; 
+  font-size: 1.2rem; 
+}
+
 @media only screen and (min-width: 769px) {
   #footer {
     background-color: $primary-nav;
-    height: 4.1rem;
+    height: 4.9rem;
     position: relative;
   }
 
@@ -43,4 +59,9 @@ a {
 
 a:hover {
   color: $bcgold;
+}
+
+#footer nav {
+  /* Remove the gold border from above nav to put it above the land acknowledgement */
+  border: none; 
 }


### PR DESCRIPTION
Ticket: [492](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=91284780&issue=bcgov%7Cparks-reso-public%7C492)
Notes: Added land acknowledgment to foot. Adjusted size of existing footer. Moved BC Gold border to above land acknowledgement. There were no designs originally included for AR but this was a close mix of examples and pre-existing footer.


![image](https://github.com/user-attachments/assets/4052e099-298b-4004-ab2a-cb63a54483f8)
