### PR TITLE
AR-393 adding standardized variance reasons

### DIFF
--- a/src/app/forms/backcountry-cabins/backcountry-cabins.component.html
+++ b/src/app/forms/backcountry-cabins/backcountry-cabins.component.html
@@ -139,14 +139,38 @@
   <!-- Variance notes -->
   <div class="form-section">
     <h2>Variance notes</h2>
-    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        [control]="varianceReasonsForm?.controls?.['reason']"
+        [loadWhile]="loading"
+        [label]="'Variance category'"
+        [selectionListItems]="varianceReasons"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        *ngIf="getVarianceSubReasons()?.length > 0"
+        [control]="varianceReasonsForm?.controls?.['subReason']"
+        [loadWhile]="loading"
+        [label]="'Subcategory'"
+        [selectionListItems]="getVarianceSubReasons()"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
     <ngds-text-input
       [control]="form?.controls?.['notes']"
       [showCharacterCount]="true"
       [multiline]="true"
       [loadWhile]="loading"
+      [label]="'Notes'"
     >
     </ngds-text-input>
+    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
   </div>
 </form>
 

--- a/src/app/forms/backcountry-camping/backcountry-camping.component.html
+++ b/src/app/forms/backcountry-camping/backcountry-camping.component.html
@@ -88,14 +88,38 @@
   <!-- Variance Notes -->
   <div class="form-section">
     <h2>Variance notes</h2>
-    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        [control]="varianceReasonsForm?.controls?.['reason']"
+        [loadWhile]="loading"
+        [label]="'Variance category'"
+        [selectionListItems]="varianceReasons"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        *ngIf="getVarianceSubReasons()?.length > 0"
+        [control]="varianceReasonsForm?.controls?.['subReason']"
+        [loadWhile]="loading"
+        [label]="'Subcategory'"
+        [selectionListItems]="getVarianceSubReasons()"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
     <ngds-text-input
       [control]="form?.controls?.['notes']"
       [showCharacterCount]="true"
       [multiline]="true"
       [loadWhile]="loading"
+      [label]="'Notes'"
     >
     </ngds-text-input>
+    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
   </div>
 </form>
 

--- a/src/app/forms/boating/boating.component.html
+++ b/src/app/forms/boating/boating.component.html
@@ -141,14 +141,38 @@
   <!-- Variance notes -->
   <div class="form-section">
     <h2>Variance notes</h2>
-    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        [control]="varianceReasonsForm?.controls?.['reason']"
+        [loadWhile]="loading"
+        [label]="'Variance category'"
+        [selectionListItems]="varianceReasons"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        *ngIf="getVarianceSubReasons()?.length > 0"
+        [control]="varianceReasonsForm?.controls?.['subReason']"
+        [loadWhile]="loading"
+        [label]="'Subcategory'"
+        [selectionListItems]="getVarianceSubReasons()"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
     <ngds-text-input
       [control]="form?.controls?.['notes']"
       [showCharacterCount]="true"
       [multiline]="true"
       [loadWhile]="loading"
+      [label]="'Notes'"
     >
     </ngds-text-input>
+    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
   </div>
 </form>
 

--- a/src/app/forms/frontcountry-cabins/frontcountry-cabins.component.html
+++ b/src/app/forms/frontcountry-cabins/frontcountry-cabins.component.html
@@ -98,14 +98,38 @@
   <!-- Variance notes -->
   <div class="form-section">
     <h2>Variance notes</h2>
-    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        [control]="varianceReasonsForm?.controls?.['reason']"
+        [loadWhile]="loading"
+        [label]="'Variance category'"
+        [selectionListItems]="varianceReasons"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        *ngIf="getVarianceSubReasons()?.length > 0"
+        [control]="varianceReasonsForm?.controls?.['subReason']"
+        [loadWhile]="loading"
+        [label]="'Subcategory'"
+        [selectionListItems]="getVarianceSubReasons()"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
     <ngds-text-input
       [control]="form?.controls?.['notes']"
       [showCharacterCount]="true"
       [multiline]="true"
       [loadWhile]="loading"
+      [label]="'Notes'"
     >
     </ngds-text-input>
+    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
   </div>
 </form>
 

--- a/src/app/forms/frontcountry-camping/frontcountry-camping.component.html
+++ b/src/app/forms/frontcountry-camping/frontcountry-camping.component.html
@@ -290,10 +290,38 @@
   <!-- Variance notes -->
   <div class="form-section">
     <h2>Variance notes</h2>
-    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
-    <ngds-text-input [control]="form?.controls?.['notes']" [showCharacterCount]="true" [multiline]="true"
-      [loadWhile]="loading">
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        [control]="varianceReasonsForm?.controls?.['reason']"
+        [loadWhile]="loading"
+        [label]="'Variance category'"
+        [selectionListItems]="varianceReasons"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        *ngIf="getVarianceSubReasons()?.length > 0"
+        [control]="varianceReasonsForm?.controls?.['subReason']"
+        [loadWhile]="loading"
+        [label]="'Subcategory'"
+        [selectionListItems]="getVarianceSubReasons()"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <ngds-text-input
+      [control]="form?.controls?.['notes']"
+      [showCharacterCount]="true"
+      [multiline]="true"
+      [loadWhile]="loading"
+      [label]="'Notes'"
+    >
     </ngds-text-input>
+    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
   </div>
 </form>
 

--- a/src/app/forms/group-camping/group-camping.component.html
+++ b/src/app/forms/group-camping/group-camping.component.html
@@ -272,14 +272,38 @@
   <!-- Variance notes -->
   <div class="form-section">
     <h2>Variance notes</h2>
-    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
+<div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        [control]="varianceReasonsForm?.controls?.['reason']"
+        [loadWhile]="loading"
+        [label]="'Variance category'"
+        [selectionListItems]="varianceReasons"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
+    <div class="row">
+      <ngds-picklist-input
+        class="col-lg-4"
+        *ngIf="getVarianceSubReasons()?.length > 0"
+        [control]="varianceReasonsForm?.controls?.['subReason']"
+        [loadWhile]="loading"
+        [label]="'Subcategory'"
+        [selectionListItems]="getVarianceSubReasons()"
+        [placeholder]="'Please select'"
+      >
+      </ngds-picklist-input>
+    </div>
     <ngds-text-input
       [control]="form?.controls?.['notes']"
       [showCharacterCount]="true"
       [multiline]="true"
       [loadWhile]="loading"
+      [label]="'Notes'"
     >
     </ngds-text-input>
+    <div>If any data entered above varies widely from the expected counts, briefly explain the variance.</div>
   </div>
 </form>
 

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -122,4 +122,120 @@ export class Constants {
       youthRateGroupsRevenueGross: 0.2,
     },
   };
+
+  public static readonly varianceReasons = [
+    {
+      value: 'Other',
+    },
+    {
+      value: 'Change in campground capacity',
+      subCategories: [
+        {
+          value: 'Sites added',
+        },
+        {
+          value: 'Sites closed',
+        },
+      ]
+    },
+    {
+      value: 'Change of operating dates',
+    },
+    {
+      value: 'Construction',
+      subCategories: [
+        {
+          value: 'Full closure due to construction',
+        },
+        {
+          value: 'Partial closure due to construction',
+        },
+        {
+          value: 'Attendance/revenue impacted due to construction',
+        },
+      ]
+    },
+    {
+      value: 'Counter unavailable/broken',
+      subCategories: [
+        {
+          value: '3 year estimate used',
+        },
+        {
+          value: 'No data',
+        }
+      ]
+    },
+    {
+      value: 'Event',
+    },
+    {
+      value: 'Flood',
+      subCategories: [
+        {
+          value: 'Flood event',
+        },
+        {
+          value: 'Existing water event',
+        }
+      ]
+    },
+    {
+      value: 'Land instability',
+    },
+    {
+      value: 'New to reservation system',
+    },
+    {
+      value: 'No senior camping parties',
+    },
+    {
+      value: 'No SSCFE or other parties',
+    },
+    {
+      value: 'Trail closure',
+    },
+    {
+      value: 'Unknown',
+    },
+    {
+      value: 'Visual count',
+    },
+    {
+      value: 'Weather',
+      subCategories: [
+        {
+          value: 'Good/Sunny weather',
+        },
+        {
+          value: 'Cold/Rainy weather',
+        },
+        {
+          value: 'Snow closure',
+        }
+      ]
+    },
+    {
+      value: 'Wildfire',
+      subCategories: [
+        {
+          value: 'Full closure',
+        },
+        {
+          value: 'Smokey conditions/poor air quality',
+        }
+      ]
+    },
+    {
+      value: 'Wildlife closure',
+      subCategories: [
+        {
+          value: 'Bear in area',
+        },
+        {
+          value: 'Human wildlife conflict',
+        }
+      ]
+    },
+  ];
 }


### PR DESCRIPTION
Relates to #393.

Variance reasons were added as an array of objects to the `constants.ts` file under `varianceReasons`. They all have a `value`, and if there are subreasons, they are listed under `subReasons`. 

Each form pulls in `Constants.varianceReasons` and is initialized with 'Other'. A picklist shows the available variance reasons. If one is selected, the `notes` field is populated with the reason. If the reason has subreasons, another picklist appears with the subreasons and the same behaviour: `notes` field adopts the subreason value if selected. The field is saved the same way as usual.

The form doesn't force the user to pick anything. 

Upon loading a previously saved activity, the notes field will have the correct value, but the variance and subvariance selections will return to their defaults - we don't need to save their values to the database.

One QOL improvement that could be added in the future is disabling the notes field if any reason other than 'OTHER' is selected, so that all the standardized options are guaranteed to be the same across all saved activities.